### PR TITLE
Added the rebuilding of the search index and disabling of Form Entry app & extension to the Activator

### DIFF
--- a/api/src/main/java/org/openmrs/module/aijar/AijarActivator.java
+++ b/api/src/main/java/org/openmrs/module/aijar/AijarActivator.java
@@ -80,6 +80,10 @@ public class AijarActivator extends org.openmrs.module.BaseModuleActivator {
         LocationService locationService = Context.getLocationService();
 
         try {
+
+            // Rebuild the concept search index
+            Context.updateSearchIndex();
+
             // disable the reference app registration page
             appFrameworkService.disableApp("referenceapplication.registrationapp.registerPatient");
             // disable the start visit app since all data is retrospective

--- a/api/src/main/java/org/openmrs/module/aijar/AijarActivator.java
+++ b/api/src/main/java/org/openmrs/module/aijar/AijarActivator.java
@@ -91,6 +91,11 @@ public class AijarActivator extends org.openmrs.module.BaseModuleActivator {
             // the extension to the edit person details
             appFrameworkService.disableExtension("org.openmrs.module.registrationapp.editPatientDemographics");
 
+            // form entry app on the home page
+            appFrameworkService.disableApp("xforms.formentry");
+            // form entry extension in active visits
+            appFrameworkService.disableExtension("xforms.formentry.cfpd");
+
             // install HTML Forms
             setupHtmlForms();
 


### PR DESCRIPTION
The concept search index needs to be rebuilt when new concepts are added to either via the API or DB script otherwise searching for concepts via the Cohort builder will fail. 