### PR TITLE
WIP:MCH Routine fixes

### DIFF
--- a/omod/src/main/webapp/resources/htmlforms/071-IntegratedAntenatalRegister.xml
+++ b/omod/src/main/webapp/resources/htmlforms/071-IntegratedAntenatalRegister.xml
@@ -49,6 +49,10 @@
 	        		NO_CONCEPT_ID = 1066,
 	        		NA_CONCEPT_ID = 1175;
 
+	        const 	TRRK_CONCEPT_ID = 99738,
+	        		TRRP_CONCEPT_ID = 99736,
+	        		TRR_CONCEPT_ID = 99315;
+
 	        const HIV_INFORMATION_SECTION = '#hiv-information-section';
 	        const ARVS_ADMINISTERED_TO_BABY_FIELD = '#arvs-administered-to-baby';
 
@@ -103,7 +107,6 @@
 	                fieldHelper.enable($hivInformationSection.find('input,select'));
 	                fieldHelper.enable($arvsGivenField);
 	                fieldHelper.enable($preArtNumberField);
-					hideOtherEmtctCodesForKnownHivPositiveStatus();
 	            } else {
 	                $hivInformationSection.find('input[type="text"],select').each(function() {
 	                	var isEmtctCodeField = jq(this).parents('span:first').length &gt; 0 &amp;&amp; jq(this).parents('span:first').attr('class').indexOf('emtct-code') != -1; //Check if current control is an eMTCT Code field
@@ -116,9 +119,8 @@
 	                fieldHelper.disable($arvsAdministeredToBabyField);
 	                fieldHelper.disable($arvsGivenField);
 	                fieldHelper.disable($preArtNumberField);
-	                showOtherEmtctCodesForKnownHivNegativeStatus();
-
 	            }
+	            
 	            viralLoadResultsChange();
 	        };
 
@@ -449,9 +451,9 @@
 					hideOtherEmtctCodesForKnownHivPositiveStatus();
 				} else {
 					hivStatusChange(HIV_NEGATIVE_CONCEPT_ID);
+					showOtherEmtctCodesForKnownHivNegativeStatus();
 				}
-
-		    };
+		    };		    
 
 	        $viralLoadResultsField.change(viralLoadResultsChange);
 	        //$lmpField.change(lmpChange);
@@ -463,6 +465,14 @@
 	        $muacQualitativeField.change(muacChange);
 	        $ancVisitField.change(ancVisitChange);
 	        $anc1TimingField.change(anc1TimingChange);
+	        $emtctCodeWomanField.change(function() {
+	        	var emtctCode = getValue('emtct-code-woman.value');
+	        	if (emtctCode == TRR_CONCEPT_ID || emtctCode == TRRK_CONCEPT_ID || emtctCode == TRRP_CONCEPT_ID ) {
+		        	hivStatusChange(HIV_POSITIVE_CONCEPT_ID);
+	        	} else {
+		        	hivStatusChange(HIV_NEGATIVE_CONCEPT_ID); 	
+	        	}
+	        });
 
 			getHivStatus();
 	        viralLoadResultsChange();
@@ -682,6 +692,46 @@
 	      <legend>HIV Information</legend>
 	      <table width="100%" border="0" cellspacing="0" cellpadding="0" id="hiv-information-section">
 	        <tr>
+	          <td colspan="2">
+	            <p>
+	              <label>eMTCT Code: Woman</label>
+	              <obs conceptId="d5b0394c-424f-41db-bc2f-37180dcdbe74" 
+	              	answerConceptIds="6da9b915-8668-4642-8ed4-7d2a346881cb, 05f16fc5-1d82-4ce8-9b44-a3125fbbf2d7, 86e394fd-8d85-4cb3-86d7-d4b9bfc3e43a, 25c448ff-5fe4-4a3a-8c0a-b5aaea9d5465, 60155e4d-1d49-4e97-9689-758315967e0f, 81bd3e58-9389-41e7-be1a-c6723f899e56,1f177240-85f6-4f10-964a-cfc7722408b3" 
+	              	answerLabels="C - Counselled but declined HIV testing,
+	              					T - Counselled and tested but didn't receive results,
+	              					TR - Counselled tested and results given - Client tested HIV - in ANC,
+	              					TRR - Counselled tested and results given - Client tested HIV + in ANC,
+	              					TRR+ - Client was originally negative but sero-converted at this test,
+	              					TR&#8730; - New ANC clients with Known HIV- status,
+	              					TRR&#8730; - New ANC clients with Known HIV+ status" 
+	                style="dropdown" required="true" class="emtct-code" id="emtct-code-woman" />
+	            </p>
+	          </td>
+	          <td colspan="2">
+	            <p>
+	              <label>eMTCT Code: Partner</label>
+	              <obs conceptId="62a37075-fc2a-4729-8950-b9fae9b22cfb" 
+	              	answerConceptIds="6da9b915-8668-4642-8ed4-7d2a346881cb,
+					              	05f16fc5-1d82-4ce8-9b44-a3125fbbf2d7,
+					              	86e394fd-8d85-4cb3-86d7-d4b9bfc3e43a,
+					              	25c448ff-5fe4-4a3a-8c0a-b5aaea9d5465,
+					              	60155e4d-1d49-4e97-9689-758315967e0f,
+					              	81bd3e58-9389-41e7-be1a-c6723f899e56,
+					              	1f177240-85f6-4f10-964a-cfc7722408b3,
+					              	8eab745c-24a5-4ba4-906c-b5087e920b66" 
+	              	answerLabels="C - Counselled but declined HIV testing,
+	              					T - Counselled and tested but didn't receive results,
+	              					TR - Counselled tested and results given - Client tested HIV - in ANC,
+	              					TRR - Counselled tested and results given - Client tested HIV + in ANC,
+	              					TRR+ - Client was originally negative but sero-converted at this test,
+	              					TR&#8730; - New ANC clients with Known HIV- status,
+	              					TRR&#8730; - New ANC clients with Known HIV+ status,
+	              					Not Tested" 
+	                style="dropdown" class="emtct-code" id="emtct-code-partner" />
+	            </p>
+	          </td>
+	        </tr>
+	        <tr>
 	          <td>
 	            <p>
 	              <label>WHO Clinical Stage</label>
@@ -732,46 +782,6 @@
 	          				answerConceptIds="a4089d8e-9ea6-4fff-b273-415c6640203a,f56e8d46-5b2f-488b-861a-94a89d16adf6"
 	          				answerLabels="Suppressed,Non-suppressed" id="viral-load-status" />
 	          	</p>
-	          </td>
-	        </tr>
-	        <tr>
-	          <td colspan="2">
-	            <p>
-	              <label>eMTCT Code: Woman</label>
-	              <obs conceptId="d5b0394c-424f-41db-bc2f-37180dcdbe74" 
-	              	answerConceptIds="6da9b915-8668-4642-8ed4-7d2a346881cb, 05f16fc5-1d82-4ce8-9b44-a3125fbbf2d7, 86e394fd-8d85-4cb3-86d7-d4b9bfc3e43a, 25c448ff-5fe4-4a3a-8c0a-b5aaea9d5465, 60155e4d-1d49-4e97-9689-758315967e0f, 81bd3e58-9389-41e7-be1a-c6723f899e56,1f177240-85f6-4f10-964a-cfc7722408b3" 
-	              	answerLabels="C - Counselled but declined HIV testing,
-	              					T - Counselled and tested but didn't receive results,
-	              					TR - Counselled tested and results given - Client tested HIV - in ANC,
-	              					TRR - Counselled tested and results given - Client tested HIV + in ANC,
-	              					TRR+ - Client was originally negative but sero-converted at this test,
-	              					TR&#8730; - New ANC clients with Known HIV- status,
-	              					TRR&#8730; - New ANC clients with Known HIV+ status" 
-	                style="dropdown" required="true" class="emtct-code" id="emtct-code-woman" />
-	            </p>
-	          </td>
-	          <td colspan="2">
-	            <p>
-	              <label>eMTCT Code: Partner</label>
-	              <obs conceptId="62a37075-fc2a-4729-8950-b9fae9b22cfb" 
-	              	answerConceptIds="6da9b915-8668-4642-8ed4-7d2a346881cb,
-					              	05f16fc5-1d82-4ce8-9b44-a3125fbbf2d7,
-					              	86e394fd-8d85-4cb3-86d7-d4b9bfc3e43a,
-					              	25c448ff-5fe4-4a3a-8c0a-b5aaea9d5465,
-					              	60155e4d-1d49-4e97-9689-758315967e0f,
-					              	81bd3e58-9389-41e7-be1a-c6723f899e56,
-					              	1f177240-85f6-4f10-964a-cfc7722408b3,
-					              	8eab745c-24a5-4ba4-906c-b5087e920b66" 
-	              	answerLabels="C - Counselled but declined HIV testing,
-	              					T - Counselled and tested but didn't receive results,
-	              					TR - Counselled tested and results given - Client tested HIV - in ANC,
-	              					TRR - Counselled tested and results given - Client tested HIV + in ANC,
-	              					TRR+ - Client was originally negative but sero-converted at this test,
-	              					TR&#8730; - New ANC clients with Known HIV- status,
-	              					TRR&#8730; - New ANC clients with Known HIV+ status,
-	              					Not Tested" 
-	                style="dropdown" class="emtct-code" id="emtct-code-partner" />
-	            </p>
 	          </td>
 	        </tr>
 	      </table>

--- a/omod/src/main/webapp/resources/htmlforms/071-IntegratedAntenatalRegister.xml
+++ b/omod/src/main/webapp/resources/htmlforms/071-IntegratedAntenatalRegister.xml
@@ -52,7 +52,6 @@
 	        const HIV_INFORMATION_SECTION = '#hiv-information-section';
 	        const ARVS_ADMINISTERED_TO_BABY_FIELD = '#arvs-administered-to-baby';
 
-	        var $hivStatusField = getField('hiv-status.value');
 	        var $viralLoadResultsField = getField('viral-load-results.value');
 	        var $lmpField = getField('lmp-date.value');
 			var $gestationAgeField = getField('gestational-age.value');
@@ -94,18 +93,11 @@
 	            }
 	        }; 
 
-	        /**
-	        * This function checks if the HIV status field has been locked(Contains the 'locked' class )
-	        */
-	        var isHivStatusFieldLocked = function () {
-	            return $hivStatusField.is('.locked');
-	        }
-
-	        var hivStatusChange = function () {
+	        var hivStatusChange = function (hivStatus) {
 	            var $hivStatus = getValue('hiv-status.value');
 	            var $hivInformationSection = jq(HIV_INFORMATION_SECTION);
 	            var $arvsAdministeredToBabyField = jq(ARVS_ADMINISTERED_TO_BABY_FIELD).find('input');
-	            if ($hivStatus == HIV_POSITIVE_CONCEPT_ID) {
+	            if (hivStatus == HIV_POSITIVE_CONCEPT_ID) {
 	                fieldHelper.enable($hivInformationSection.find('input'));
 	                fieldHelper.enable($arvsAdministeredToBabyField);
 	                fieldHelper.enable($hivInformationSection.find('input,select'));
@@ -115,7 +107,7 @@
 	            } else {
 	                $hivInformationSection.find('input[type="text"],select').each(function() {
 	                	var isEmtctCodeField = jq(this).parents('span:first').length &gt; 0 &amp;&amp; jq(this).parents('span:first').attr('class').indexOf('emtct-code') != -1; //Check if current control is an eMTCT Code field
-	                    if (jq(this).attr('id') == $hivStatusField.attr('id') || isEmtctCodeField ) {
+	                    if ( isEmtctCodeField ) {
 	                        fieldHelper.enable(jq(this));
 	                    } else {
 	                        fieldHelper.disable(jq(this));
@@ -432,7 +424,7 @@
 		    };
 
 		    var showOtherEmtctCodesForKnownHivNegativeStatus = function() {
-				var emtctCodesToHide = [99738];
+				var emtctCodesToHide = [];
 				var emtctControlsToHide =  $emtctCodeWomanField.children('option').filter(function() {
 					return emtctCodesToHide.indexOf(parseInt(this.value)) &gt; -1;
 				});
@@ -442,18 +434,6 @@
 		    };
 
 		    var getHivStatus = function () {
-		    	/**
-		    	* HIV Status field should be selected if patient is HIV +ve 
-		    	*/
-				var hivStatus = <lookup complexExpression="#set ($hivStatus = $fn.earliestObs(HIV_STATUS_CONCEPT_ID).valueCoded)
-															#if ($hivStatus) $hivStatus;
-															#else '';
-															#end" />
-
-				if (hivStatus == HIV_POSITIVE_CONCEPT_ID) {
-					$hivStatusField.val(hivStatus);
-				}
-
 				/**
 				* Make HIV Status field not changeable only if the encounter date of the ART summary 
 				* page encounter (as we shall be entering retrospective data) is before the date of 
@@ -465,24 +445,15 @@
 																		#else '';
 																		#end"/>
 				if (artSummaryEncounterDate !='' &amp;&amp; artSummaryEncounterDate &lt; visitDate) {
-					$hivStatusField.addClass('locked');
-					$hivStatusField.val(HIV_POSITIVE_CONCEPT_ID);
-					$hivStatusField.change();
+					hivStatusChange(HIV_POSITIVE_CONCEPT_ID);
 					hideOtherEmtctCodesForKnownHivPositiveStatus();
 				} else {
-					fieldHelper.enable($hivStatusField);
+					hivStatusChange(HIV_NEGATIVE_CONCEPT_ID);
 				}
+
 		    };
 
 	        $viralLoadResultsField.change(viralLoadResultsChange);
-	        $hivStatusField.change(function(){
-	            if (isHivStatusFieldLocked()) {
-					setValue('hiv-status.value',HIV_POSITIVE_CONCEPT_ID);
-	            } else {
-	            	hivStatusChange();
-	            }
-	        });
-	        $hivStatusField.change(hivStatusChange);
 	        //$lmpField.change(lmpChange);
 	        $eddField.change(eddChange);
 	        $gestationAgeField.change(setAnc1Timing);
@@ -495,7 +466,6 @@
 
 			getHivStatus();
 	        viralLoadResultsChange();
-	        hivStatusChange();
 	        ancVisitChange();
 			toggleOtherSpecify();
 
@@ -583,6 +553,58 @@
         </fieldset>
 
         <fieldset>
+            <legend>Mother's Information</legend>
+            <table width="100%" border="0" cellspacing="0" cellpadding="0" id="mothers-information-section">
+                <tr>
+                    <td>
+                        <p>
+                            <label>Gravida</label>
+                            <obs conceptId="dcc39097-30ab-102d-86b0-7a5022ba4115" id="gravida" />
+                        </p>
+                    </td>
+                    <td>
+                        <p>
+                            <label>Parity</label>
+                            <obs conceptId="1053AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" id="parity" />
+                        </p>
+                    </td>
+                    <td>
+                        <p>
+                            <label>Gestational Age</label>
+                            <obs conceptId="dca0a383-30ab-102d-86b0-7a5022ba4115" id="gestational-age" required="true" />
+                        </p>
+                    </td>
+                    <td>
+                        <p>
+                            <label>Expected Date Of Delivery</label>
+                            <obs conceptId="dcc033e5-30ab-102d-86b0-7a5022ba4115" id="edd" allowFutureDates="true" />
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <p>
+                            <label>L.N.M.P</label>
+                            <obs conceptId="27d8e650-615a-473c-954f-ec934b0131d5" id="lmp-date" />
+                        </p>
+                    </td>
+                    <td>
+                        <p>
+                            <label>ANC 1 Timing</label>
+                            <obs conceptId="3a862ab6-7601-4412-b626-d373c1d4a51e" labelText=""
+                                 answerConceptIds="1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,dc9b0596-30ab-102d-86b0-7a5022ba4115"
+                                 answerLabels="&#8730; - Yes,X - No ,N/A" id="anc1-timing" />
+                        </p>
+                    </td>
+                    <td>                       
+                    </td>
+                    <td>
+                    </td>
+                </tr>
+            </table>
+        </fieldset>
+
+        <fieldset>
         	<legend>Vitals</legend>
                 <table>
                     <tr>
@@ -656,70 +678,10 @@
                 </table>
         </fieldset>
 
-        <fieldset>
-            <legend>Mother's Information</legend>
-            <table width="100%" border="0" cellspacing="0" cellpadding="0" id="mothers-information-section">
-                <tr>
-                    <td>
-                        <p>
-                            <label>Gravida</label>
-                            <obs conceptId="dcc39097-30ab-102d-86b0-7a5022ba4115" id="gravida" />
-                        </p>
-                    </td>
-                    <td>
-                        <p>
-                            <label>Parity</label>
-                            <obs conceptId="1053AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" id="parity" />
-                        </p>
-                    </td>
-                    <td>
-                        <p>
-                            <label>Gestational Age</label>
-                            <obs conceptId="dca0a383-30ab-102d-86b0-7a5022ba4115" id="gestational-age" required="true" />
-                        </p>
-                    </td>
-                    <td>
-                        <p>
-                            <label>Expected Date Of Delivery</label>
-                            <obs conceptId="dcc033e5-30ab-102d-86b0-7a5022ba4115" id="edd" allowFutureDates="true" required="true" />
-                        </p>
-                    </td>
-                </tr>
-                <tr>
-                    <td>
-                        <p>
-                            <label>L.N.M.P</label>
-                            <obs conceptId="27d8e650-615a-473c-954f-ec934b0131d5" id="lmp-date" />
-                        </p>
-                    </td>
-                    <td>
-                        <p>
-                            <label>ANC 1 Timing</label>
-                            <obs conceptId="3a862ab6-7601-4412-b626-d373c1d4a51e" labelText=""
-                                 answerConceptIds="1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,dc9b0596-30ab-102d-86b0-7a5022ba4115"
-                                 answerLabels="&#8730; - Yes,X - No ,N/A" id="anc1-timing" />
-                        </p>
-                    </td>
-                    <td>                       
-                    </td>
-                    <td>
-                    </td>
-                </tr>
-            </table>
-        </fieldset>
-
 	    <fieldset>
 	      <legend>HIV Information</legend>
 	      <table width="100%" border="0" cellspacing="0" cellpadding="0" id="hiv-information-section">
 	        <tr>
-	          <td>
-	            <p>
-	              <label>HIV Status</label>
-	              <obs conceptId="dce0e886-30ab-102d-86b0-7a5022ba4115" 
-	              	   answerConceptIds="dcdf4241-30ab-102d-86b0-7a5022ba4115,dcdf4653-30ab-102d-86b0-7a5022ba4115,1067AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" 
-	              	   style="dropdown" id="hiv-status" required="true" />
-	            </p>
-	          </td>
 	          <td>
 	            <p>
 	              <label>WHO Clinical Stage</label>
@@ -740,6 +702,7 @@
 	              <obs conceptId="dcbcba2c-30ab-102d-86b0-7a5022ba4115" />
 	            </p>
 	          </td>
+	          <td></td>
 	        </tr>
 	        <tr>
 	          <td>
@@ -791,14 +754,22 @@
 	            <p>
 	              <label>eMTCT Code: Partner</label>
 	              <obs conceptId="62a37075-fc2a-4729-8950-b9fae9b22cfb" 
-	              	answerConceptIds="6da9b915-8668-4642-8ed4-7d2a346881cb, 05f16fc5-1d82-4ce8-9b44-a3125fbbf2d7, 86e394fd-8d85-4cb3-86d7-d4b9bfc3e43a, 25c448ff-5fe4-4a3a-8c0a-b5aaea9d5465, 60155e4d-1d49-4e97-9689-758315967e0f, 81bd3e58-9389-41e7-be1a-c6723f899e56,1f177240-85f6-4f10-964a-cfc7722408b3" 
+	              	answerConceptIds="6da9b915-8668-4642-8ed4-7d2a346881cb,
+					              	05f16fc5-1d82-4ce8-9b44-a3125fbbf2d7,
+					              	86e394fd-8d85-4cb3-86d7-d4b9bfc3e43a,
+					              	25c448ff-5fe4-4a3a-8c0a-b5aaea9d5465,
+					              	60155e4d-1d49-4e97-9689-758315967e0f,
+					              	81bd3e58-9389-41e7-be1a-c6723f899e56,
+					              	1f177240-85f6-4f10-964a-cfc7722408b3,
+					              	8eab745c-24a5-4ba4-906c-b5087e920b66" 
 	              	answerLabels="C - Counselled but declined HIV testing,
 	              					T - Counselled and tested but didn't receive results,
 	              					TR - Counselled tested and results given - Client tested HIV - in ANC,
 	              					TRR - Counselled tested and results given - Client tested HIV + in ANC,
 	              					TRR+ - Client was originally negative but sero-converted at this test,
 	              					TR&#8730; - New ANC clients with Known HIV- status,
-	              					TRR&#8730; - New ANC clients with Known HIV+ status" 
+	              					TRR&#8730; - New ANC clients with Known HIV+ status,
+	              					Not Tested" 
 	                style="dropdown" class="emtct-code" id="emtct-code-partner" />
 	            </p>
 	          </td>
@@ -890,8 +861,14 @@
                         <p>
                             <label>TB Status</label>
                             <obs conceptId="dce02aa1-30ab-102d-86b0-7a5022ba4115"
-                                 answerConceptIds="dcdaccc1-30ab-102d-86b0-7a5022ba4115,dcdaaf0f-30ab-102d-86b0-7a5022ba4115,dcdac38b-30ab-102d-86b0-7a5022ba4115,dcdaa6b4-30ab-102d-86b0-7a5022ba4115"
-                                 answerLabels="No Signs - No signs or symptoms of TB,Presumptive (Suspect) - TB refer or sputum sent,TB Diagnosed - Diagnosed with TB,TB Rx - CUrrently on TB treatment"
+                                 answerConceptIds="dcdaccc1-30ab-102d-86b0-7a5022ba4115,
+					                                 dcdaaf0f-30ab-102d-86b0-7a5022ba4115,
+					                                 dcdac38b-30ab-102d-86b0-7a5022ba4115,
+					                                 dcdaa6b4-30ab-102d-86b0-7a5022ba4115"
+                                 answerLabels="1. No Signs - No signs or symptoms of TB,
+	                                 			2. Presumptive (Suspect) - TB refer or sputum sent,
+	                                 			3. TB Diagnosed - Diagnosed with TB,
+	                                 			4. TB Rx - CUrrently on TB treatment"
                                  style="dropdown" />
                         </p>
                     </td>

--- a/omod/src/main/webapp/resources/htmlforms/072-IntegratedMaternityRegister.xml
+++ b/omod/src/main/webapp/resources/htmlforms/072-IntegratedMaternityRegister.xml
@@ -27,14 +27,6 @@
 	<ifMode mode="ENTER">
 			<script>
 				jQuery(document).ready(function() {
-					/*
-					 * If a mother is already in care (has an ART encounter) then the HIV+ field must be automatically selected
-					 */
-					<includeIf velocityTest="$fn.allEncounters('8d5b2be0-c2cc-11de-8d13-0010c6dffd0f').size() &gt; 0">
-						setValue('hiv-status.value', 90166);
-					</includeIf>
-					
-
 					<!--
 					 /*
 					 *When the page is loaded with no providers with the Midwife role - a Javascript message must be shown and the user forwarded to the manage Users page
@@ -86,6 +78,10 @@
 
 	        const YES_CONCEPT_ID = 1065;
 	        const NO_CONCEPT_ID = 1066;
+
+	        const 	TRRK_CONCEPT_ID = 99738,
+	        		TRRP_CONCEPT_ID = 99736,
+	        		TRR_CONCEPT_ID = 99315;
 
 	        const HIV_INFORMATION_SECTION = '#hiv-information-section';
 	        const PRE_ART_NUMBER_FIELD = '#pre-art-number';
@@ -144,7 +140,6 @@
 	                fieldHelper.enable($arvsAdministeredToBabyField);
 	                fieldHelper.enable($hivInformationSection.find('input,select'));
 	                fieldHelper.enable($preArtNumberField);
-					hideOtherEmtctCodesForKnownHivPositiveStatus();
 	            } else {
 	                $hivInformationSection.find('input[type="text"],select').each(function() {
 	                	var isEmtctCodeField = jq(this).parents('span:first').length &gt; 0 &amp;&amp; jq(this).parents('span:first').attr('class').indexOf('emtct-code') != -1; //Check if current control is an eMTCT Code field
@@ -156,8 +151,6 @@
 	                });
 	                fieldHelper.disable($arvsAdministeredToBabyField);
 	                fieldHelper.disable($preArtNumberField);
-	                showOtherEmtctCodesForKnownHivNegativeStatus();
-
 	            }
 	            viralLoadResultsChange();
 	        };
@@ -384,8 +377,8 @@
 					hideOtherEmtctCodesForKnownHivPositiveStatus();
 				} else {
 					hivStatusChange(HIV_NEGATIVE_CONCEPT_ID);
+					showOtherEmtctCodesForKnownHivNegativeStatus();
 				}
-
 		    };
 
 			var babyValidated = function () {
@@ -427,6 +420,14 @@
 	        $diagnosisParentFields.change(diagnosisParentFieldsChange);
 	        $diagnosisChildFields.change(diagnosisChildFieldsChange);
 	        $encounterDateField.change(getHivStatus);
+	        $emtctCodeWomanField.change(function() {
+	        	var emtctCode = getValue('emtct-code-woman.value');
+	        	if (emtctCode == TRR_CONCEPT_ID || emtctCode == TRRK_CONCEPT_ID || emtctCode == TRRP_CONCEPT_ID ) {
+		        	hivStatusChange(HIV_POSITIVE_CONCEPT_ID);
+	        	} else {
+		        	hivStatusChange(HIV_NEGATIVE_CONCEPT_ID); 	
+	        	}
+	        });
 
 			getHivStatus();
 	        viralLoadResultsChange();
@@ -713,6 +714,56 @@
       <legend>HIV Information</legend>
       <table width="100%" border="0" cellspacing="0" cellpadding="0" id="hiv-information-section">
         <tr>
+          <td colspan="2">
+            <p>
+              <label>eMTCT Code: Woman</label>
+              <obs conceptId="d5b0394c-424f-41db-bc2f-37180dcdbe74" 
+              	answerConceptIds="6da9b915-8668-4642-8ed4-7d2a346881cb,
+				              	05f16fc5-1d82-4ce8-9b44-a3125fbbf2d7,
+				              	86e394fd-8d85-4cb3-86d7-d4b9bfc3e43a,
+				              	a08d9331-b437-485c-8eff-1923f3d43630,
+				              	25c448ff-5fe4-4a3a-8c0a-b5aaea9d5465,
+				              	60155e4d-1d49-4e97-9689-758315967e0f,
+				              	81bd3e58-9389-41e7-be1a-c6723f899e56,
+				              	1f177240-85f6-4f10-964a-cfc7722408b3" 
+              	answerLabels=	"C - Counselled but declined HIV testing,
+              					T - Counselled and tested but didn't receive results,
+              					TR - Counselled tested and results given - Client tested HIV - in maternity,
+              					TR+ - Tested HIV- on retest,
+              					TRR - Counselled tested and results given - Client tested HIV + in maternity,
+              					TRR+ - Client was originally negative but sero-converted at this test,
+              					TRK - New ANC clients with Known HIV- status,
+              					TRRK - New ANC clients with Known HIV+ status" 
+	                style="dropdown" required="true" class="emtct-code" id="emtct-code-woman" />
+            </p>
+          </td>
+          <td colspan="2">
+            <p>
+              <label>eMTCT Code: Partner</label>
+              <obs conceptId="62a37075-fc2a-4729-8950-b9fae9b22cfb" 
+              	answerConceptIds="6da9b915-8668-4642-8ed4-7d2a346881cb,
+				              	05f16fc5-1d82-4ce8-9b44-a3125fbbf2d7,
+				              	86e394fd-8d85-4cb3-86d7-d4b9bfc3e43a,
+				              	a08d9331-b437-485c-8eff-1923f3d43630,
+				              	25c448ff-5fe4-4a3a-8c0a-b5aaea9d5465,
+				              	60155e4d-1d49-4e97-9689-758315967e0f,
+				              	81bd3e58-9389-41e7-be1a-c6723f899e56,
+				              	1f177240-85f6-4f10-964a-cfc7722408b3,
+				              	8eab745c-24a5-4ba4-906c-b5087e920b66" 
+              	answerLabels="C - Counselled but declined HIV testing,
+              					T - Counselled and tested but didn't receive results,
+              					TR - Counselled tested and results given - Client tested HIV - in maternity,
+              					TR+ - Tested HIV- on retest,
+              					TRR - Counselled tested and results given - Client tested HIV + in maternity,
+              					TRR+ - Client was originally negative but sero-converted at this test,
+              					TRK - New ANC clients with Known HIV- status,
+              					TRRK - New ANC clients with Known HIV+ status,
+	              				Not Tested"
+	                style="dropdown" class="emtct-code" id="emtct-code-partner" />
+            </p>
+          </td>
+        </tr>
+        <tr>
           <td>
             <p>
               <label>WHO Clinical Stage</label>
@@ -761,56 +812,6 @@
           				answerConceptIds="a4089d8e-9ea6-4fff-b273-415c6640203a,f56e8d46-5b2f-488b-861a-94a89d16adf6"
           				answerLabels="Suppressed,Non-suppressed" id="viral-load-status" />
           	</p>
-          </td>
-        </tr>
-        <tr>
-          <td colspan="2">
-            <p>
-              <label>eMTCT Code: Woman</label>
-              <obs conceptId="d5b0394c-424f-41db-bc2f-37180dcdbe74" 
-              	answerConceptIds="6da9b915-8668-4642-8ed4-7d2a346881cb,
-				              	05f16fc5-1d82-4ce8-9b44-a3125fbbf2d7,
-				              	86e394fd-8d85-4cb3-86d7-d4b9bfc3e43a,
-				              	a08d9331-b437-485c-8eff-1923f3d43630,
-				              	25c448ff-5fe4-4a3a-8c0a-b5aaea9d5465,
-				              	60155e4d-1d49-4e97-9689-758315967e0f,
-				              	81bd3e58-9389-41e7-be1a-c6723f899e56,
-				              	1f177240-85f6-4f10-964a-cfc7722408b3" 
-              	answerLabels=	"C - Counselled but declined HIV testing,
-              					T - Counselled and tested but didn't receive results,
-              					TR - Counselled tested and results given - Client tested HIV - in maternity,
-              					TR+ - Tested HIV- on retest,
-              					TRR - Counselled tested and results given - Client tested HIV + in maternity,
-              					TRR+ - Client was originally negative but sero-converted at this test,
-              					TRK - New ANC clients with Known HIV- status,
-              					TRRK - New ANC clients with Known HIV+ status" 
-	                style="dropdown" required="true" class="emtct-code" id="emtct-code-woman" />
-            </p>
-          </td>
-          <td colspan="2">
-            <p>
-              <label>eMTCT Code: Partner</label>
-              <obs conceptId="62a37075-fc2a-4729-8950-b9fae9b22cfb" 
-              	answerConceptIds="6da9b915-8668-4642-8ed4-7d2a346881cb,
-				              	05f16fc5-1d82-4ce8-9b44-a3125fbbf2d7,
-				              	86e394fd-8d85-4cb3-86d7-d4b9bfc3e43a,
-				              	a08d9331-b437-485c-8eff-1923f3d43630,
-				              	25c448ff-5fe4-4a3a-8c0a-b5aaea9d5465,
-				              	60155e4d-1d49-4e97-9689-758315967e0f,
-				              	81bd3e58-9389-41e7-be1a-c6723f899e56,
-				              	1f177240-85f6-4f10-964a-cfc7722408b3,
-				              	8eab745c-24a5-4ba4-906c-b5087e920b66" 
-              	answerLabels="C - Counselled but declined HIV testing,
-              					T - Counselled and tested but didn't receive results,
-              					TR - Counselled tested and results given - Client tested HIV - in maternity,
-              					TR+ - Tested HIV- on retest,
-              					TRR - Counselled tested and results given - Client tested HIV + in maternity,
-              					TRR+ - Client was originally negative but sero-converted at this test,
-              					TRK - New ANC clients with Known HIV- status,
-              					TRRK - New ANC clients with Known HIV+ status,
-	              				Not Tested"
-	                style="dropdown" class="emtct-code" id="emtct-code-partner" />
-            </p>
           </td>
         </tr>
       </table>

--- a/omod/src/main/webapp/resources/htmlforms/072-IntegratedMaternityRegister.xml
+++ b/omod/src/main/webapp/resources/htmlforms/072-IntegratedMaternityRegister.xml
@@ -92,7 +92,8 @@
 	        const ARVS_ADMINISTERED_TO_BABY_FIELD = '#arvs-administered-to-baby';
 	        const IYCF_FIELD = '#iycf';
 
-	        var $hivStatusField = getField('hiv-status.value');
+            var $viralLoadField = getField('viral-load.value');
+			var $viralLoadStatusField = getField('viral-load-status.value');
 	        var $viralLoadResultsField = getField('viral-load-results.value');
 	        var $iycfField = jq(IYCF_FIELD).find('input');
 	        var $arvsToMotherField = getField('arvs-to-mother.value');
@@ -106,47 +107,57 @@
 
 	        var viralLoadResultsChange = function() {
 	            var $viralLoadResults = getValue('viral-load-results.value');
-	            var $viralLoadField = getField('viral-load.value');
-
 	            fieldHelper.removeReadonly($viralLoadField);
 	            fieldHelper.enable($viralLoadField);
+	            fieldHelper.disable($viralLoadStatusField);
 	            if ($viralLoadResults == VIRAL_LOAD_NOT_DETECTED_CONCEPT_ID) { //if viral load quantitive is 'not detected' set a viral load count of 1
 	                $viralLoadField.val(1);
 	                $viralLoadField.change();
 	                fieldHelper.makeReadonly($viralLoadField);
+					setValue('viral-load-status.value','');
 	            } else if($viralLoadResults == VIRAL_LOAD_DETECTED_CONCEPT_ID) { //if viral load quantitive is 'detected' allow for entry of viral load count
 	                if ($viralLoadField.val() == 1) {
 		                $viralLoadField.val("");
 		                $viralLoadField.change();
 	                }
+	                fieldHelper.enable($viralLoadStatusField);
 	            } else { //if viral load quantitive is 'rejected' clear viral load count field
 	                $viralLoadField.val("");
 	                $viralLoadField.change();
 	                fieldHelper.disable($viralLoadField);
+					setValue('viral-load-status.value','');
 	            }
 	        };
 
-	        var hivStatusChange = function () {
-	            var $hivStatus = getValue('hiv-status.value');
+	        /**
+	        * This function checks if the HIV status field has been locked(Contains the 'locked' class )
+	        */
+	        var isHivStatusFieldLocked = function () {
+	            return $hivStatusField.is('.locked');
+	        }
+
+	        var hivStatusChange = function (hivStatus) {
 	            var $hivInformationSection = jq(HIV_INFORMATION_SECTION);
 	            var $arvsAdministeredToBabyField = jq(ARVS_ADMINISTERED_TO_BABY_FIELD).find('input');
-	            if ($hivStatus == HIV_POSITIVE_CONCEPT_ID) {
+	            if (hivStatus == HIV_POSITIVE_CONCEPT_ID) {
 	                fieldHelper.enable($hivInformationSection.find('input'));
 	                fieldHelper.enable($arvsAdministeredToBabyField);
 	                fieldHelper.enable($hivInformationSection.find('input,select'));
-	                fieldHelper.enable($arvsToMotherField);
+	                fieldHelper.enable($preArtNumberField);
+					hideOtherEmtctCodesForKnownHivPositiveStatus();
 	            } else {
-	                $hivInformationSection.find('input,select').each(function() {
+	                $hivInformationSection.find('input[type="text"],select').each(function() {
 	                	var isEmtctCodeField = jq(this).parents('span:first').length &gt; 0 &amp;&amp; jq(this).parents('span:first').attr('class').indexOf('emtct-code') != -1; //Check if current control is an eMTCT Code field
-
-	                    if (jq(this).attr('id') == $hivStatusField.attr('id') || isEmtctCodeField ) {
+	                    if ( isEmtctCodeField ) {
 	                        fieldHelper.enable(jq(this));
 	                    } else {
 	                        fieldHelper.disable(jq(this));
 	                    }
 	                });
-	                $arvsAdministeredToBabyField.attr('disabled', true);
-	                fieldHelper.disable($arvsToMotherField);
+	                fieldHelper.disable($arvsAdministeredToBabyField);
+	                fieldHelper.disable($preArtNumberField);
+	                showOtherEmtctCodesForKnownHivNegativeStatus();
+
 	            }
 	            viralLoadResultsChange();
 	        };
@@ -348,7 +359,7 @@
 		    };
 
 		    var showOtherEmtctCodesForKnownHivNegativeStatus = function() {
-				var emtctCodesToHide = [99738];
+				var emtctCodesToHide = [];
 				var emtctControlsToHide =  $emtctCodeWomanField.children('option').filter(function() {
 					return emtctCodesToHide.indexOf(parseInt(this.value)) &gt; -1;
 				});
@@ -358,18 +369,6 @@
 		    };
 
 		    var getHivStatus = function () {
-		    	/**
-		    	* HIV Status field should be selected if patient is HIV +ve 
-		    	*/
-				var hivStatus = <lookup complexExpression="#set ($hivStatus = $fn.earliestObs(HIV_STATUS_CONCEPT_ID).valueCoded)
-															#if ($hivStatus) $hivStatus;
-															#else '';
-															#end" />
-
-				if (hivStatus == HIV_POSITIVE_CONCEPT_ID) {
-					$hivStatusField.val(hivStatus);
-				}
-
 				/**
 				* Make HIV Status field not changeable only if the encounter date of the ART summary 
 				* page encounter (as we shall be entering retrospective data) is before the date of 
@@ -381,49 +380,13 @@
 																		#else '';
 																		#end"/>
 				if (artSummaryEncounterDate !='' &amp;&amp; artSummaryEncounterDate &lt; visitDate) {
-					$hivStatusField.addClass('locked');
-					$hivStatusField.val(HIV_POSITIVE_CONCEPT_ID);
-					$hivStatusField.change();
+					hivStatusChange(HIV_POSITIVE_CONCEPT_ID);
 					hideOtherEmtctCodesForKnownHivPositiveStatus();
 				} else {
-					fieldHelper.enable($hivStatusField);
+					hivStatusChange(HIV_NEGATIVE_CONCEPT_ID);
 				}
+
 		    };
-
-	        /**
-	        * This function checks if the HIV status field has been locked(Contains the 'locked' class )
-	        */
-	        var isHivStatusFieldLocked = function () {
-	            return $hivStatusField.is('.locked');
-	        }
-
-	        var hivStatusChange = function () {
-	            var $hivStatus = getValue('hiv-status.value');
-	            var $hivInformationSection = jq(HIV_INFORMATION_SECTION);
-	            var $arvsAdministeredToBabyField = jq(ARVS_ADMINISTERED_TO_BABY_FIELD).find('input');
-	            if ($hivStatus == HIV_POSITIVE_CONCEPT_ID) {
-	                fieldHelper.enable($hivInformationSection.find('input'));
-	                fieldHelper.enable($arvsAdministeredToBabyField);
-	                fieldHelper.enable($hivInformationSection.find('input,select'));
-	                fieldHelper.enable($arvsToMotherField);
-	                fieldHelper.enable($preArtNumberField);
-	                hideOtherEmtctCodesForKnownHivPositiveStatus();
-	            } else {
-	                $hivInformationSection.find('input[type="text"],select').each(function() {
-	                	var isEmtctCodeField = jq(this).parents('span:first').length &gt; 0 &amp;&amp; jq(this).parents('span:first').attr('class').indexOf('emtct-code') != -1; //Check if current control is an eMTCT Code field
-	                    if (jq(this).attr('id') == $hivStatusField.attr('id') || isEmtctCodeField ) {
-	                        fieldHelper.enable(jq(this));
-	                    } else {
-	                        fieldHelper.disable(jq(this));
-	                    }
-	                });
-	                fieldHelper.disable($arvsAdministeredToBabyField);
-	                fieldHelper.disable($arvsToMotherField);
-	                fieldHelper.disable($preArtNumberField);
-					showOtherEmtctCodesForKnownHivNegativeStatus();
-	            }
-	            viralLoadResultsChange();
-	        };
 
 			var babyValidated = function () {
 			    var $tables;
@@ -457,15 +420,7 @@
 
 	        $othersField.change(toggleOtherSpecify);
 
-	        $hivStatusField.change(function(){
-	            if (isHivStatusFieldLocked()) {
-					setValue('hiv-status.value',HIV_POSITIVE_CONCEPT_ID);
-	            } else {
-	            	hivStatusChange();
-	            }
-	        });
 	        $viralLoadResultsField.change(viralLoadResultsChange);
-	        $hivStatusField.change(hivStatusChange);
 	        $iycfField.change(iycfChange);
 	        $arvsToMotherField.change(arvsToMotherChange);
 	        $gestationWeeksField.change(setDelivery);
@@ -475,7 +430,6 @@
 
 			getHivStatus();
 	        viralLoadResultsChange();
-	        hivStatusChange();
 	        iycfChange();
 	        arvsToMotherChange();
 	        $diagnosisParentFields.each(diagnosisParentFieldsChange);
@@ -665,7 +619,7 @@
           <td>
             <p>
               <label>Weeks of gestation</label>
-              <obs conceptId="8c40b914-10a0-4f77-92ba-db242973748f" id="gestation-weeks"/>
+              <obs conceptId="dca0a383-30ab-102d-86b0-7a5022ba4115" id="gestation-weeks"/>
             </p>
           </td>
           <td>
@@ -761,12 +715,6 @@
         <tr>
           <td>
             <p>
-              <label>HIV Status</label>
-              <obs conceptId="dce0e886-30ab-102d-86b0-7a5022ba4115" answerConceptIds="dcdf4241-30ab-102d-86b0-7a5022ba4115,dcdf4653-30ab-102d-86b0-7a5022ba4115,1067AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" style="dropdown" id="hiv-status" required="true"/>
-            </p>
-          </td>
-          <td>
-            <p>
               <label>WHO Clinical Stage</label>
               <obs conceptId="dcdff274-30ab-102d-86b0-7a5022ba4115"
                    answerConceptIds="dcda2bc2-30ab-102d-86b0-7a5022ba4115,dcda3251-30ab-102d-86b0-7a5022ba4115,dcda3663-30ab-102d-86b0-7a5022ba4115,dcda3a80-30ab-102d-86b0-7a5022ba4115,dd25e735-30ab-102d-86b0-7a5022ba4115,dd2666a5-30ab-102d-86b0-7a5022ba4115,dd266d64-30ab-102d-86b0-7a5022ba4115,dd269c18-30ab-102d-86b0-7a5022ba4115"
@@ -785,6 +733,7 @@
               <obs conceptId="dcbcba2c-30ab-102d-86b0-7a5022ba4115" />
             </p>
           </td>
+          <td></td>
         </tr>
         <tr>
           <td>
@@ -805,7 +754,14 @@
               <obs conceptId="dc8d83e3-30ab-102d-86b0-7a5022ba4115" id="viral-load" />
             </p>
           </td>
-          <td></td>
+          <td>
+          	<p>
+          		<label>Viral Load Status</label>
+          		<obs 	conceptId="fcb5ef91-ad8f-44bc-ac5f-9ffb29881e59" 
+          				answerConceptIds="a4089d8e-9ea6-4fff-b273-415c6640203a,f56e8d46-5b2f-488b-861a-94a89d16adf6"
+          				answerLabels="Suppressed,Non-suppressed" id="viral-load-status" />
+          	</p>
+          </td>
         </tr>
         <tr>
           <td colspan="2">
@@ -842,7 +798,8 @@
 				              	25c448ff-5fe4-4a3a-8c0a-b5aaea9d5465,
 				              	60155e4d-1d49-4e97-9689-758315967e0f,
 				              	81bd3e58-9389-41e7-be1a-c6723f899e56,
-				              	1f177240-85f6-4f10-964a-cfc7722408b3" 
+				              	1f177240-85f6-4f10-964a-cfc7722408b3,
+				              	8eab745c-24a5-4ba4-906c-b5087e920b66" 
               	answerLabels="C - Counselled but declined HIV testing,
               					T - Counselled and tested but didn't receive results,
               					TR - Counselled tested and results given - Client tested HIV - in maternity,
@@ -850,7 +807,8 @@
               					TRR - Counselled tested and results given - Client tested HIV + in maternity,
               					TRR+ - Client was originally negative but sero-converted at this test,
               					TRK - New ANC clients with Known HIV- status,
-              					TRRK - New ANC clients with Known HIV+ status" 
+              					TRRK - New ANC clients with Known HIV+ status,
+	              				Not Tested"
 	                style="dropdown" class="emtct-code" id="emtct-code-partner" />
             </p>
           </td>

--- a/omod/src/main/webapp/resources/htmlforms/078-IntegratedPostnatalRegister.xml
+++ b/omod/src/main/webapp/resources/htmlforms/078-IntegratedPostnatalRegister.xml
@@ -47,6 +47,10 @@
 	    			RED_CONCEPT_ID = 99028,
 	    			GREEN_CONCEPT_ID = 99027;
 
+	        const 	TRRK_CONCEPT_ID = 99738,
+	        		TRRP_CONCEPT_ID = 99736,
+	        		TRR_CONCEPT_ID = 99315;
+
 	        const NORMAL_DELIVERY_CONCEPT_ID = 1170;
 
 	        const HIV_INFORMATION_SECTION = '#hiv-information-section';
@@ -118,7 +122,6 @@
 	                fieldHelper.enable($arvsAdministeredToBabyField);
 	                fieldHelper.enable($hivInformationSection.find('input,select'));
 	                fieldHelper.enable($preArtNumberField);
-					hideOtherEmtctCodesForKnownHivPositiveStatus();
 	            } else {
 	                $hivInformationSection.find('input[type="text"],select').each(function() {
 	                	var isEmtctCodeField = jq(this).parents('span:first').length &gt; 0 &amp;&amp; jq(this).parents('span:first').attr('class').indexOf('emtct-code') != -1; //Check if current control is an eMTCT Code field
@@ -130,7 +133,6 @@
 	                });
 	                fieldHelper.disable($arvsAdministeredToBabyField);
 	                fieldHelper.disable($preArtNumberField);
-	                showOtherEmtctCodesForKnownHivNegativeStatus();
 
 	            }
 	            viralLoadResultsChange();
@@ -277,6 +279,7 @@
 					hideOtherEmtctCodesForKnownHivPositiveStatus();
 				} else {
 					hivStatusChange(HIV_NEGATIVE_CONCEPT_ID);
+					showOtherEmtctCodesForKnownHivNegativeStatus();
 				}
 		    };
 
@@ -285,6 +288,14 @@
 	        $encounterDateField.change(getHivStatus);
 	        $muacQuantitativeField.change(muacChange);
 	        $muacQualitativeField.change(muacChange);
+	        $emtctCodeWomanField.change(function() {
+	        	var emtctCode = getValue('emtct-code-woman.value');
+	        	if (emtctCode == TRR_CONCEPT_ID || emtctCode == TRRK_CONCEPT_ID || emtctCode == TRRP_CONCEPT_ID ) {
+		        	hivStatusChange(HIV_POSITIVE_CONCEPT_ID);
+	        	} else {
+		        	hivStatusChange(HIV_NEGATIVE_CONCEPT_ID); 	
+	        	}
+	        });
 			
 			getHivStatus();
 	        viralLoadResultsChange();
@@ -501,6 +512,57 @@
 	      <legend>HIV Information</legend>
 	      <table width="100%" border="0" cellspacing="0" cellpadding="0" id="hiv-information-section">
 	        <tr>
+	          <td colspan="2">
+	            <p>
+	              <label>eMTCT Code: Woman</label>
+	              <obs conceptId="d5b0394c-424f-41db-bc2f-37180dcdbe74" 
+	              	answerConceptIds="6da9b915-8668-4642-8ed4-7d2a346881cb,
+					              	05f16fc5-1d82-4ce8-9b44-a3125fbbf2d7,
+					              	86e394fd-8d85-4cb3-86d7-d4b9bfc3e43a,
+					              	25c448ff-5fe4-4a3a-8c0a-b5aaea9d5465,
+					              	a08d9331-b437-485c-8eff-1923f3d43630,
+					              	60155e4d-1d49-4e97-9689-758315967e0f,
+					              	81bd3e58-9389-41e7-be1a-c6723f899e56,
+					              	1f177240-85f6-4f10-964a-cfc7722408b3" 
+	              	answerLabels="C - Counselled but declined HIV testing,
+	              					T - Counselled and tested but didn't receive results,
+	              					TR - Counselled tested and results given - Client tested HIV- in PNC,
+	              					TRR - Counselled tested and results given - Client tested HIV+ in PNC,
+	              					TR+ - Client tested HIV- on a re-test,
+	              					TRR+ - Client tested HIV+ on a re-test,
+	              					TR&#8730; - Client tested on a previous visit with known HIV- status,
+	              					TRR&#8730; - Client tested on previous visit with known HIV+ status" 
+	                style="dropdown" required="true" class="emtct-code" id="emtct-code-woman"/>
+	            </p>
+	          </td>
+	          <td colspan="2">
+	            <p>
+	              <label>eMTCT Code: Partner</label>
+	              <obs conceptId="d5b0394c-424f-41db-bc2f-37180dcdbe74" 
+	              	answerConceptIds="6da9b915-8668-4642-8ed4-7d2a346881cb,
+					              	05f16fc5-1d82-4ce8-9b44-a3125fbbf2d7,
+					              	86e394fd-8d85-4cb3-86d7-d4b9bfc3e43a,
+					              	25c448ff-5fe4-4a3a-8c0a-b5aaea9d5465,
+					              	a08d9331-b437-485c-8eff-1923f3d43630,
+					              	60155e4d-1d49-4e97-9689-758315967e0f,
+									81bd3e58-9389-41e7-be1a-c6723f899e56,
+									1f177240-85f6-4f10-964a-cfc7722408b3,
+					              	8eab745c-24a5-4ba4-906c-b5087e920b66"
+	              	answerLabels="C - Counselled but declined HIV testing,
+	              					T - Counselled and tested but didn't receive results,
+	              					TR - Counselled tested and results given - Client tested HIV- in PNC,
+	              					TRR - Counselled tested and results given - Client tested HIV+ in PNC,
+	              					TR+ - Client tested HIV- on a re-test,
+	              					TRR+ - Client tested HIV+ on a re-test,
+	              					TR&#8730; - Client tested on a previous visit with known HIV- status,
+	              					TRR&#8730; - Client tested on previous visit with known HIV+ status,
+	              					Not Tested" 
+	                style="dropdown" class="emtct-code" id="emtct-code-man" />
+
+	            </p>
+	          </td>
+	        </tr>
+	        <tr>
 	          <td>
 	            <p>
 	              <label>WHO Clinical Stage</label>
@@ -551,57 +613,6 @@
 	          				answerConceptIds="a4089d8e-9ea6-4fff-b273-415c6640203a,f56e8d46-5b2f-488b-861a-94a89d16adf6"
 	          				answerLabels="Suppressed,Non-suppressed" id="viral-load-status" />
 	          	</p>
-	          </td>
-	        </tr>
-	        <tr>
-	          <td colspan="2">
-	            <p>
-	              <label>eMTCT Code: Woman</label>
-	              <obs conceptId="d5b0394c-424f-41db-bc2f-37180dcdbe74" 
-	              	answerConceptIds="6da9b915-8668-4642-8ed4-7d2a346881cb,
-					              	05f16fc5-1d82-4ce8-9b44-a3125fbbf2d7,
-					              	86e394fd-8d85-4cb3-86d7-d4b9bfc3e43a,
-					              	25c448ff-5fe4-4a3a-8c0a-b5aaea9d5465,
-					              	a08d9331-b437-485c-8eff-1923f3d43630,
-					              	60155e4d-1d49-4e97-9689-758315967e0f,
-					              	81bd3e58-9389-41e7-be1a-c6723f899e56,
-					              	1f177240-85f6-4f10-964a-cfc7722408b3" 
-	              	answerLabels="C - Counselled but declined HIV testing,
-	              					T - Counselled and tested but didn't receive results,
-	              					TR - Counselled tested and results given - Client tested HIV- in PNC,
-	              					TRR - Counselled tested and results given - Client tested HIV+ in PNC,
-	              					TR+ - Client tested HIV- on a re-test,
-	              					TRR+ - Client tested HIV+ on a re-test,
-	              					TR&#8730; - Client tested on a previous visit with known HIV- status,
-	              					TRR&#8730; - Client tested on previous visit with known HIV+ status" 
-	                style="dropdown" required="true" class="emtct-code" id="emtct-code-woman"/>
-	            </p>
-	          </td>
-	          <td colspan="2">
-	            <p>
-	              <label>eMTCT Code: Partner</label>
-	              <obs conceptId="d5b0394c-424f-41db-bc2f-37180dcdbe74" 
-	              	answerConceptIds="6da9b915-8668-4642-8ed4-7d2a346881cb,
-					              	05f16fc5-1d82-4ce8-9b44-a3125fbbf2d7,
-					              	86e394fd-8d85-4cb3-86d7-d4b9bfc3e43a,
-					              	25c448ff-5fe4-4a3a-8c0a-b5aaea9d5465,
-					              	a08d9331-b437-485c-8eff-1923f3d43630,
-					              	60155e4d-1d49-4e97-9689-758315967e0f,
-									81bd3e58-9389-41e7-be1a-c6723f899e56,
-									1f177240-85f6-4f10-964a-cfc7722408b3,
-					              	8eab745c-24a5-4ba4-906c-b5087e920b66"
-	              	answerLabels="C - Counselled but declined HIV testing,
-	              					T - Counselled and tested but didn't receive results,
-	              					TR - Counselled tested and results given - Client tested HIV- in PNC,
-	              					TRR - Counselled tested and results given - Client tested HIV+ in PNC,
-	              					TR+ - Client tested HIV- on a re-test,
-	              					TRR+ - Client tested HIV+ on a re-test,
-	              					TR&#8730; - Client tested on a previous visit with known HIV- status,
-	              					TRR&#8730; - Client tested on previous visit with known HIV+ status,
-	              					Not Tested" 
-	                style="dropdown" class="emtct-code" id="emtct-code-man" />
-
-	            </p>
 	          </td>
 	        </tr>
 	      </table>

--- a/omod/src/main/webapp/resources/htmlforms/078-IntegratedPostnatalRegister.xml
+++ b/omod/src/main/webapp/resources/htmlforms/078-IntegratedPostnatalRegister.xml
@@ -53,7 +53,6 @@
 	        const PRE_ART_NUMBER_FIELD = '#pre-art-number';
 	        const ARVS_ADMINISTERED_TO_BABY_FIELD = '#arvs-administered-to-baby';
 
-	        var $hivStatusField = getField('hiv-status.value');
 	        var $viralLoadResultsField = getField('viral-load-results.value');
 	        var $arvsToMotherField = getField('arvs-to-mother.value');
 	        var $encounterDateField = jq('#encounter-date').find('input[type="hidden"]');
@@ -111,34 +110,28 @@
 	            return $hivStatusField.is('.locked');
 	        }
 
-	        var hivStatusChange = function () {
-	            var $hivStatus = getValue('hiv-status.value');
+	        var hivStatusChange = function (hivStatus) {
 	            var $hivInformationSection = jq(HIV_INFORMATION_SECTION);
 	            var $arvsAdministeredToBabyField = jq(ARVS_ADMINISTERED_TO_BABY_FIELD).find('input');
-
-	            if ($hivStatus == HIV_POSITIVE_CONCEPT_ID) {
+	            if (hivStatus == HIV_POSITIVE_CONCEPT_ID) {
 	                fieldHelper.enable($hivInformationSection.find('input'));
 	                fieldHelper.enable($arvsAdministeredToBabyField);
 	                fieldHelper.enable($hivInformationSection.find('input,select'));
-	                fieldHelper.enable($arvsToMotherField);
-	                fieldHelper.enable($arvsGivenField);
 	                fieldHelper.enable($preArtNumberField);
-	                fieldHelper.enable($septrinField);
+					hideOtherEmtctCodesForKnownHivPositiveStatus();
 	            } else {
-	                $hivInformationSection.find('input,select').each(function() {
+	                $hivInformationSection.find('input[type="text"],select').each(function() {
 	                	var isEmtctCodeField = jq(this).parents('span:first').length &gt; 0 &amp;&amp; jq(this).parents('span:first').attr('class').indexOf('emtct-code') != -1; //Check if current control is an eMTCT Code field
-
-	                    if (jq(this).attr('id') == $hivStatusField.attr('id') || isEmtctCodeField ) {
+	                    if ( isEmtctCodeField ) {
 	                        fieldHelper.enable(jq(this));
 	                    } else {
 	                        fieldHelper.disable(jq(this));
 	                    }
 	                });
 	                fieldHelper.disable($arvsAdministeredToBabyField);
-	                fieldHelper.disable($arvsToMotherField);
-	                fieldHelper.disable($arvsGivenField);
 	                fieldHelper.disable($preArtNumberField);
-	                fieldHelper.disable($septrinField);
+	                showOtherEmtctCodesForKnownHivNegativeStatus();
+
 	            }
 	            viralLoadResultsChange();
 	        };
@@ -248,31 +241,26 @@
 				var emtctControlsToHide =  $emtctCodeWomanField.children('option').filter(function() {
 					return emtctCodesToHide.indexOf(parseInt(this.value)) &gt; -1;
 				});
+				$emtctCodeWomanField.children('option').attr('disabled', false);
 				emtctControlsToHide.attr('disabled', true);
 				setValue('emtct-code-woman.value', 99738);
 		    };
 
-		    var hideOtherHivStatusOPtionsForKnownHivPositiveStatus = function() {
-				var hivStatusCodesToHide = [90167,1067];
-				var hivStatusControlsToHide =  $hivStatusField.children('option').filter(function() {
-					return hivStatusCodesToHide.indexOf(parseInt(this.value)) &gt; -1;
+		    var showOtherEmtctCodesForKnownHivNegativeStatus = function() {
+				var emtctCodesToHide = [];
+				var emtctControlsToHide =  $emtctCodeWomanField.children('option').filter(function() {
+					return emtctCodesToHide.indexOf(parseInt(this.value)) &gt; -1;
 				});
-				hivStatusControlsToHide.remove();
+				$emtctCodeWomanField.children('option').attr('disabled', false);
+				emtctControlsToHide.attr('disabled', true);
+				setValue('emtct-code-woman.value', '');
 		    };
 
 		    var getHivStatus = function () {
-		    	/**
-		    	* HIV Status field should be selected if patient is HIV +ve 
-		    	*/
-
 				var hivStatus = <lookup complexExpression="#set ($hivStatus = $fn.earliestObs(HIV_STATUS_CONCEPT_ID).valueCoded)
 															#if ($hivStatus) $hivStatus;
 															#else '';
 															#end" />
-
-				if (hivStatus == HIV_POSITIVE_CONCEPT_ID) {
-					$hivStatusField.val(hivStatus);
-				}
 
 				/**
 				* Make HIV Status field not changeable only if the encounter date of the ART summary 
@@ -285,24 +273,14 @@
 																		#else '';
 																		#end"/>
 				if (artSummaryEncounterDate !='' &amp;&amp; artSummaryEncounterDate &lt; visitDate) {
-					$hivStatusField.addClass('locked');
-					$hivStatusField.val(HIV_POSITIVE_CONCEPT_ID);
-					$hivStatusField.change();
+					hivStatusChange(HIV_POSITIVE_CONCEPT_ID);
 					hideOtherEmtctCodesForKnownHivPositiveStatus();
-					hideOtherHivStatusOPtionsForKnownHivPositiveStatus();					
 				} else {
-					fieldHelper.enable($hivStatusField);
+					hivStatusChange(HIV_NEGATIVE_CONCEPT_ID);
 				}
 		    };
 
 	        $viralLoadResultsField.change(viralLoadResultsChange);
-	        $hivStatusField.change(function(){
-	            if (isHivStatusFieldLocked()) {
-					setValue('hiv-status.value',HIV_POSITIVE_CONCEPT_ID);
-	            } else {
-	            	hivStatusChange();
-	            }
-	        });
 	        $othersField.change(toggleOtherSpecify);
 	        $encounterDateField.change(getHivStatus);
 	        $muacQuantitativeField.change(muacChange);
@@ -310,7 +288,6 @@
 			
 			getHivStatus();
 	        viralLoadResultsChange();
-	        hivStatusChange();
 			setNormalDeliveryStatus();
 			toggleOtherSpecify();
 
@@ -514,8 +491,7 @@
 	                            <obs conceptId="b644c29c-9bb0-447e-9f73-2ae89496a709" id="inrNumber" />
 	                        </p>
 	                    </td>
-	                    <td></td>
-	                    <td></td>
+	                    <td colspan="2"></td>
 	                </tr>
 	            </table>
 			</section>
@@ -525,14 +501,6 @@
 	      <legend>HIV Information</legend>
 	      <table width="100%" border="0" cellspacing="0" cellpadding="0" id="hiv-information-section">
 	        <tr>
-	          <td>
-	            <p>
-	              <label>HIV Status</label>
-	              <obs conceptId="dce0e886-30ab-102d-86b0-7a5022ba4115" 
-	              	   answerConceptIds="dcdf4241-30ab-102d-86b0-7a5022ba4115,dcdf4653-30ab-102d-86b0-7a5022ba4115,1067AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" 
-	              	   style="dropdown" id="hiv-status" required="true"/>
-	            </p>
-	          </td>
 	          <td>
 	            <p>
 	              <label>WHO Clinical Stage</label>
@@ -553,6 +521,7 @@
 	              <obs conceptId="dcbcba2c-30ab-102d-86b0-7a5022ba4115" />
 	            </p>
 	          </td>
+	          <td></td>
 	        </tr>
 	        <tr>
 	          <td>
@@ -589,8 +558,14 @@
 	            <p>
 	              <label>eMTCT Code: Woman</label>
 	              <obs conceptId="d5b0394c-424f-41db-bc2f-37180dcdbe74" 
-	              	answerConceptIds="6da9b915-8668-4642-8ed4-7d2a346881cb, 05f16fc5-1d82-4ce8-9b44-a3125fbbf2d7, 86e394fd-8d85-4cb3-86d7-d4b9bfc3e43a, 25c448ff-5fe4-4a3a-8c0a-b5aaea9d5465, a08d9331-b437-485c-8eff-1923f3d43630
-, 60155e4d-1d49-4e97-9689-758315967e0f, 81bd3e58-9389-41e7-be1a-c6723f899e56,1f177240-85f6-4f10-964a-cfc7722408b3" 
+	              	answerConceptIds="6da9b915-8668-4642-8ed4-7d2a346881cb,
+					              	05f16fc5-1d82-4ce8-9b44-a3125fbbf2d7,
+					              	86e394fd-8d85-4cb3-86d7-d4b9bfc3e43a,
+					              	25c448ff-5fe4-4a3a-8c0a-b5aaea9d5465,
+					              	a08d9331-b437-485c-8eff-1923f3d43630,
+					              	60155e4d-1d49-4e97-9689-758315967e0f,
+					              	81bd3e58-9389-41e7-be1a-c6723f899e56,
+					              	1f177240-85f6-4f10-964a-cfc7722408b3" 
 	              	answerLabels="C - Counselled but declined HIV testing,
 	              					T - Counselled and tested but didn't receive results,
 	              					TR - Counselled tested and results given - Client tested HIV- in PNC,
@@ -606,8 +581,15 @@
 	            <p>
 	              <label>eMTCT Code: Partner</label>
 	              <obs conceptId="d5b0394c-424f-41db-bc2f-37180dcdbe74" 
-	              	answerConceptIds="6da9b915-8668-4642-8ed4-7d2a346881cb, 05f16fc5-1d82-4ce8-9b44-a3125fbbf2d7, 86e394fd-8d85-4cb3-86d7-d4b9bfc3e43a, 25c448ff-5fe4-4a3a-8c0a-b5aaea9d5465, a08d9331-b437-485c-8eff-1923f3d43630
-, 60155e4d-1d49-4e97-9689-758315967e0f, 81bd3e58-9389-41e7-be1a-c6723f899e56,1f177240-85f6-4f10-964a-cfc7722408b3" 
+	              	answerConceptIds="6da9b915-8668-4642-8ed4-7d2a346881cb,
+					              	05f16fc5-1d82-4ce8-9b44-a3125fbbf2d7,
+					              	86e394fd-8d85-4cb3-86d7-d4b9bfc3e43a,
+					              	25c448ff-5fe4-4a3a-8c0a-b5aaea9d5465,
+					              	a08d9331-b437-485c-8eff-1923f3d43630,
+					              	60155e4d-1d49-4e97-9689-758315967e0f,
+									81bd3e58-9389-41e7-be1a-c6723f899e56,
+									1f177240-85f6-4f10-964a-cfc7722408b3,
+					              	8eab745c-24a5-4ba4-906c-b5087e920b66"
 	              	answerLabels="C - Counselled but declined HIV testing,
 	              					T - Counselled and tested but didn't receive results,
 	              					TR - Counselled tested and results given - Client tested HIV- in PNC,
@@ -615,7 +597,8 @@
 	              					TR+ - Client tested HIV- on a re-test,
 	              					TRR+ - Client tested HIV+ on a re-test,
 	              					TR&#8730; - Client tested on a previous visit with known HIV- status,
-	              					TRR&#8730; - Client tested on previous visit with known HIV+ status" 
+	              					TRR&#8730; - Client tested on previous visit with known HIV+ status,
+	              					Not Tested" 
 	                style="dropdown" class="emtct-code" id="emtct-code-man" />
 
 	            </p>


### PR DESCRIPTION
@ssmusoke, feedback for the MCH forms has been acted upon and ready for review
1. Global (Antenatal, Maternity and Postnatal)
	EMTCT Code for TRRK for woman has to be available for mothers without an existing ART encounter since A woman with known HIV status may come for ANC, Maternity or PNC 
	Remove HIV Status field which is confusing, this information has to be ascertained from the EMTCT codes for the woman 
	EMTCT Code for Partner - add a Not Tested option which is very common as partners are not usually tested 
2. Maternity 
	The form does not save for weeks of gestation greater than 34, remove this restriction 
3. Antenatal 
	Routine Administration - Add the codes for TB Status
	Remove required field on EDD since in certain cases this cannot be established so is left blank 
	Move mother's information before vitals as the register is structured this way 
cc @ningosi 
![image](https://user-images.githubusercontent.com/1963527/27408943-a2a0681e-56e7-11e7-8c83-7aa3504a4d4c.png)
