### PR TITLE
Exclude Patient Flags From Dead  and Transfered Patient's dash board

### DIFF
--- a/api/src/main/java/org/openmrs/module/aijar/metadata/core/Flags.java
+++ b/api/src/main/java/org/openmrs/module/aijar/metadata/core/Flags.java
@@ -10,11 +10,13 @@ public class Flags {
     public static FlagDescriptor DUE_FOR_FIRST_VIRAL_LOAD = new FlagDescriptor() {
         @Override
         public String criteria() {
-            return "SELECT p.patient_id, DATE_FORMAT(DATE_ADD(o.value_datetime, INTERVAL 6 MONTH), '%d.%b.%Y') FROM patient p " +
-                    " INNER JOIN obs o ON p.patient_id = o.person_id " +
-                    " INNER JOIN encounter e ON o.encounter_id = e.encounter_id " +
-                    " INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id " +
-                    " WHERE ((o.concept_id = 99161 AND o.voided = FALSE AND e.voided = FALSE AND ((CURRENT_DATE() BETWEEN DATE_ADD(o.value_datetime, INTERVAL 5 MONTH) AND DATE_ADD(o.value_datetime, INTERVAL 6 MONTH)) AND et.uuid='8d5b27bc-c2cc-11de-8d13-0010c6dffd0f'))) AND o.person_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 1305 AND oo.voided = FALSE)";
+            return "SELECT p.patient_id, DATE_FORMAT(DATE_ADD(o.value_datetime, INTERVAL 6 MONTH), '%d.%b.%Y') FROM patient p \n" +
+                    " INNER JOIN obs o ON p.patient_id = o.person_id  INNER JOIN encounter e ON o.encounter_id = e.encounter_id  \n" +
+                    " INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id \n" +
+                    "  WHERE ((o.concept_id = 99161 AND o.voided = FALSE AND e.voided = FALSE AND ((CURRENT_DATE() BETWEEN DATE_ADD(o.value_datetime, INTERVAL 5 MONTH) AND DATE_ADD(o.value_datetime, INTERVAL 6 MONTH)) AND et.uuid='8d5b27bc-c2cc-11de-8d13-0010c6dffd0f'))) AND o.person_id \n" +
+                    "  NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 1305 AND oo.voided = FALSE)\n" +
+                    " AND p.patient_id NOT IN (select person_id from person where dead !=\"false\")\n" +
+                    " AND p.patient_id NOT IN (select o.person_id from obs o where concept_id=90306 and o.voided=0)";
         }
 
         @Override
@@ -51,10 +53,11 @@ public class Flags {
     public static FlagDescriptor OVERDUE_FOR_FIRST_VIRAL_LOAD = new FlagDescriptor() {
         @Override
         public String criteria() {
-            return "SELECT p.patient_id, DATE_FORMAT(DATE_ADD(o.value_datetime, INTERVAL 6 MONTH), '%d.%b.%Y') FROM patient p " +
-                    " INNER JOIN obs o ON p.patient_id = o.person_id " +
-                    " WHERE o.concept_id = 99161 AND o.voided = FALSE AND CURRENT_DATE() >= DATE_ADD(o.value_datetime, INTERVAL 6 MONTH) " +
-                    " AND o.person_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 1305 AND oo.voided = FALSE)";
+            return "SELECT p.patient_id, DATE_FORMAT(DATE_ADD(o.value_datetime, INTERVAL 6 MONTH), '%d.%b.%Y') FROM patient p  \n" +
+                    " INNER JOIN obs o ON p.patient_id = o.person_id  WHERE o.concept_id = 99161 AND o.voided = FALSE AND CURRENT_DATE() >= DATE_ADD(o.value_datetime, INTERVAL 6 MONTH)  AND o.person_id \n" +
+                    " NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 1305 AND oo.voided = FALSE)\n" +
+                    " AND p.patient_id NOT IN (select person_id from person where dead !=\"false\")\n" +
+                    " AND p.patient_id NOT IN (select o.person_id from obs o where concept_id=90306 and o.voided=0)";
         }
 
         @Override
@@ -91,12 +94,11 @@ public class Flags {
     public static FlagDescriptor DUE_FOR_ROUTINE_VIRAL_LOAD = new FlagDescriptor() {
         @Override
         public String criteria() {
-            return "SELECT p.patient_id, DATE_FORMAT(IF(TIMESTAMPDIFF(YEAR, pe.birthdate, CURDATE()) < 16, DATE_ADD(MAX(o.value_datetime), INTERVAL 6 MONTH), DATE_ADD(MAX(o.value_datetime), INTERVAL 12 MONTH)), '%d.%b.%Y') FROM patient p " +
-                    "  INNER JOIN obs o ON p.patient_id = o.person_id " +
-                    "  INNER JOIN person pe ON o.person_id = pe.person_id " +
-                    " WHERE o.concept_id = 163023 AND o.voided = FALSE " +
-                    " GROUP BY pe.person_id, pe.birthdate " +
-                    " HAVING DATEDIFF(IF(TIMESTAMPDIFF(YEAR, pe.birthdate, CURDATE()) < 16, DATE_ADD(MAX(o.value_datetime), INTERVAL 6 MONTH), DATE_ADD(MAX(o.value_datetime), INTERVAL 12 MONTH)), CURRENT_DATE()) BETWEEN 0 AND 30";
+            return " SELECT p.patient_id, DATE_FORMAT(IF(TIMESTAMPDIFF(YEAR, pe.birthdate, CURDATE()) < 16, DATE_ADD(MAX(o.value_datetime), INTERVAL 6 MONTH), DATE_ADD(MAX(o.value_datetime), INTERVAL 12 MONTH)), '%d.%b.%Y') FROM patient p  \n" +
+                    "  INNER JOIN obs o ON p.patient_id = o.person_id   INNER JOIN person pe ON o.person_id = pe.person_id  WHERE o.concept_id = 163023 AND o.voided = FALSE  GROUP BY pe.person_id, pe.birthdate \n" +
+                    "   HAVING DATEDIFF(IF(TIMESTAMPDIFF(YEAR, pe.birthdate, CURDATE()) < 16, DATE_ADD(MAX(o.value_datetime), INTERVAL 6 MONTH), DATE_ADD(MAX(o.value_datetime), INTERVAL 12 MONTH)), CURRENT_DATE()) BETWEEN 0 AND 30\n" +
+                    "   AND p.patient_id NOT IN (select person_id from person where dead !=\"false\")\n" +
+                    " AND p.patient_id NOT IN (select o.person_id from obs o where concept_id=90306 and o.voided=0)";
         }
 
         @Override
@@ -133,12 +135,11 @@ public class Flags {
     public static FlagDescriptor OVERDUE_FOR_ROUTINE_VIRAL_LOAD = new FlagDescriptor() {
         @Override
         public String criteria() {
-            return "SELECT p.patient_id, DATE_FORMAT(IF(TIMESTAMPDIFF(YEAR, pe.birthdate, CURDATE()) < 16, DATE_ADD(MAX(o.value_datetime), INTERVAL 6 MONTH), DATE_ADD(MAX(o.value_datetime), INTERVAL 12 MONTH)), '%d.%b.%Y') FROM patient p " +
-                    "  INNER JOIN obs o ON p.patient_id = o.person_id " +
-                    "  INNER JOIN person pe ON o.person_id = pe.person_id " +
-                    " WHERE o.concept_id = 163023 AND o.voided = FALSE " +
-                    " GROUP BY pe.person_id, pe.birthdate " +
-                    " HAVING CURRENT_DATE() > IF(TIMESTAMPDIFF(YEAR, pe.birthdate, CURDATE()) < 16, DATE_ADD(MAX(o.value_datetime), INTERVAL 6 MONTH), DATE_ADD(MAX(o.value_datetime), INTERVAL 12 MONTH))";
+            return "SELECT p.patient_id, DATE_FORMAT(IF(TIMESTAMPDIFF(YEAR, pe.birthdate, CURDATE()) < 16, DATE_ADD(MAX(o.value_datetime), INTERVAL 6 MONTH), DATE_ADD(MAX(o.value_datetime), INTERVAL 12 MONTH)), '%d.%b.%Y') FROM patient p  \n" +
+                    "  INNER JOIN obs o ON p.patient_id = o.person_id   INNER JOIN person pe ON o.person_id = pe.person_id  WHERE o.concept_id = 163023 AND o.voided = FALSE  GROUP BY pe.person_id, pe.birthdate \n" +
+                    "   HAVING CURRENT_DATE() > IF(TIMESTAMPDIFF(YEAR, pe.birthdate, CURDATE()) < 16, DATE_ADD(MAX(o.value_datetime), INTERVAL 6 MONTH), DATE_ADD(MAX(o.value_datetime), INTERVAL 12 MONTH))\n" +
+                    "   AND p.patient_id NOT IN (select person_id from person where dead !=\"false\")\n" +
+                    " AND p.patient_id NOT IN (select o.person_id from obs o where concept_id=90306 and o.voided=0)";
         }
 
         @Override
@@ -175,7 +176,10 @@ public class Flags {
     public static FlagDescriptor UPCOMING_APPOINTMENT = new FlagDescriptor() {
         @Override
         public String criteria() {
-            return "SELECT p.patient_id, DATE_FORMAT(MAX(o.value_datetime), '%d.%b.%Y') FROM patient p INNER JOIN obs o ON p.patient_id = o.person_id WHERE o.concept_id = 5096 AND o.voided = FALSE  GROUP BY o.person_id HAVING MAX(o.value_datetime) >= CURRENT_DATE()";
+            return "SELECT p.patient_id, DATE_FORMAT(MAX(o.value_datetime), '%d.%b.%Y') FROM patient p \n" +
+                    " INNER JOIN obs o ON p.patient_id = o.person_id WHERE o.concept_id = 5096 AND o.voided = FALSE  GROUP BY o.person_id HAVING MAX(o.value_datetime) >= CURRENT_DATE()\n" +
+                    " AND p.patient_id NOT IN (select person_id from person where dead !=\"false\")\n" +
+                    " AND p.patient_id NOT IN (select o.person_id from obs o where concept_id=90306 and o.voided=0)";
         }
 
         @Override
@@ -212,7 +216,10 @@ public class Flags {
     public static FlagDescriptor MISSED_APPOINTMENT = new FlagDescriptor() {
         @Override
         public String criteria() {
-            return "SELECT p.patient_id, DATE_FORMAT(MAX(o.value_datetime), '%d.%b.%Y') FROM patient p INNER JOIN obs o ON p.patient_id = o.person_id WHERE o.concept_id = 5096 AND o.voided = FALSE GROUP BY o.person_id HAVING MAX(o.value_datetime) BETWEEN DATE_SUB(CURRENT_DATE(), INTERVAL 29 DAY) AND DATE_SUB(CURRENT_DATE(), INTERVAL 7 DAY)";
+            return " SELECT p.patient_id, DATE_FORMAT(MAX(o.value_datetime), '%d.%b.%Y') FROM patient p\n" +
+                    "  INNER JOIN obs o ON p.patient_id = o.person_id WHERE o.concept_id = 5096 AND o.voided = FALSE GROUP BY o.person_id HAVING MAX(o.value_datetime) BETWEEN DATE_SUB(CURRENT_DATE(), INTERVAL 29 DAY) AND DATE_SUB(CURRENT_DATE(), INTERVAL 7 DAY)\n" +
+                    " AND p.patient_id NOT IN (select person_id from person where dead !=\"false\")\n" +
+                    " AND p.patient_id NOT IN (select o.person_id from obs o where concept_id=90306 and o.voided=0)";
         }
 
         @Override
@@ -249,7 +256,10 @@ public class Flags {
     public static FlagDescriptor PATIENT_LOST = new FlagDescriptor() {
         @Override
         public String criteria() {
-            return "SELECT p.patient_id, DATE_FORMAT(DATE_ADD(MAX(o.value_datetime), INTERVAL 30 DAY), '%d.%b.%Y') FROM patient p INNER JOIN obs o ON p.patient_id = o.person_id WHERE o.concept_id = 5096 AND o.voided = FALSE GROUP BY o.person_id HAVING MAX(o.value_datetime) BETWEEN DATE_SUB(CURRENT_DATE(), INTERVAL 89 DAY) AND DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY)";
+            return " SELECT p.patient_id, DATE_FORMAT(DATE_ADD(MAX(o.value_datetime), INTERVAL 30 DAY), '%d.%b.%Y') FROM patient p\n" +
+                    "  INNER JOIN obs o ON p.patient_id = o.person_id WHERE o.concept_id = 5096 AND o.voided = FALSE GROUP BY o.person_id HAVING MAX(o.value_datetime) BETWEEN DATE_SUB(CURRENT_DATE(), INTERVAL 89 DAY) AND DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY)\n" +
+                    " AND p.patient_id NOT IN (select person_id from person where dead !=\"false\")\n" +
+                    " AND p.patient_id NOT IN (select o.person_id from obs o where concept_id=90306 and o.voided=0)";
         }
 
         @Override
@@ -286,7 +296,10 @@ public class Flags {
     public static FlagDescriptor PATIENT_LOST_TO_FOLLOWUP = new FlagDescriptor() {
         @Override
         public String criteria() {
-            return "SELECT p.patient_id, DATE_FORMAT(DATE_ADD(MAX(o.value_datetime), INTERVAL 90 DAY), '%d.%b.%Y') FROM patient p INNER JOIN obs o ON p.patient_id = o.person_id WHERE o.concept_id = 5096 AND o.voided = FALSE GROUP BY o.person_id HAVING MAX(o.value_datetime) <= DATE_SUB(CURRENT_DATE(), INTERVAL 90 DAY)";
+            return "SELECT p.patient_id, DATE_FORMAT(DATE_ADD(MAX(o.value_datetime), INTERVAL 90 DAY), '%d.%b.%Y') FROM patient p \n" +
+                    "INNER JOIN obs o ON p.patient_id = o.person_id WHERE o.concept_id = 5096 AND o.voided = FALSE GROUP BY o.person_id HAVING MAX(o.value_datetime) <= DATE_SUB(CURRENT_DATE(), INTERVAL 90 DAY)\n" +
+                    "AND p.patient_id NOT IN (select person_id from person where dead !=\"false\")\n" +
+                    "AND p.patient_id NOT IN (select o.person_id from obs o where concept_id=90306 and o.voided=0)";
         }
 
         @Override
@@ -323,15 +336,14 @@ public class Flags {
     public static FlagDescriptor DUE_FOR_FIRST_DNA_PCR = new FlagDescriptor() {
         @Override
         public String criteria() {
-            return "SELECT p.patient_id , DATE_FORMAT(DATE_ADD(pe.birthdate, INTERVAL 6 WEEK), '%d.%b.%Y') FROM patient p " +
-                    "  INNER JOIN obs o ON p.patient_id = o.person_id " +
-                    "  INNER JOIN person pe ON p.patient_id = pe.person_id " +
-                    "  INNER JOIN encounter e ON o.encounter_id = e.encounter_id " +
-                    "  INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id " +
-                    "  WHERE (TIMESTAMPDIFF(WEEK, pe.birthdate, CURDATE()) BETWEEN 6 AND 9) AND et.uuid='9fcfcc91-ad60-4d84-9710-11cc25258719' " +
-                    "        AND p.patient_id NOT IN (SELECT ee.patient_id FROM encounter ee INNER JOIN encounter_type ete ON ee.encounter_type = ete.encounter_type_id WHERE ete.uuid = '8d5b27bc-c2cc-11de-8d13-0010c6dffd0f' AND ee.voided = FALSE) " +
-                    " GROUP BY p.patient_id " +
-                    " HAVING p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 99606 AND oo.voided = FALSE) ";
+            return " SELECT p.patient_id , DATE_FORMAT(DATE_ADD(pe.birthdate, INTERVAL 6 WEEK), '%d.%b.%Y') FROM patient p \n" +
+                    "   INNER JOIN obs o ON p.patient_id = o.person_id   INNER JOIN person pe ON p.patient_id = pe.person_id   \n" +
+                    "   INNER JOIN encounter e ON o.encounter_id = e.encounter_id \n" +
+                    "   INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id   WHERE (TIMESTAMPDIFF(WEEK, pe.birthdate, CURDATE()) BETWEEN 6 AND 9) AND et.uuid='9fcfcc91-ad60-4d84-9710-11cc25258719'   \n" +
+                    "         AND p.patient_id NOT IN (SELECT ee.patient_id FROM encounter ee INNER JOIN encounter_type ete ON ee.encounter_type = ete.encounter_type_id WHERE ete.uuid = '8d5b27bc-c2cc-11de-8d13-0010c6dffd0f' AND ee.voided = FALSE)  GROUP BY p.patient_id  \n" +
+                    "         HAVING p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 99606 AND oo.voided = FALSE)\n" +
+                    "AND p.patient_id NOT IN (select person_id from person where dead !=\"false\")\n" +
+                    " AND p.patient_id NOT IN (select o.person_id from obs o where concept_id=90306 and o.voided=0)";
         }
 
         @Override
@@ -368,15 +380,14 @@ public class Flags {
     public static FlagDescriptor OVERDUE_FOR_FIRST_DNA_PCR = new FlagDescriptor() {
         @Override
         public String criteria() {
-            return "SELECT p.patient_id , DATE_FORMAT(DATE_ADD(pe.birthdate, INTERVAL 6 WEEK), '%d.%b.%Y') FROM patient p " +
-                    "  INNER JOIN obs o ON p.patient_id = o.person_id " +
-                    "  INNER JOIN person pe ON p.patient_id = pe.person_id " +
-                    "  INNER JOIN encounter e ON o.encounter_id = e.encounter_id " +
-                    "  INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id " +
-                    "  WHERE (TIMESTAMPDIFF(WEEK, pe.birthdate, CURDATE()) BETWEEN 10 AND 24) AND et.uuid='9fcfcc91-ad60-4d84-9710-11cc25258719' " +
-                    "        AND p.patient_id NOT IN (SELECT ee.patient_id FROM encounter ee INNER JOIN encounter_type ete ON ee.encounter_type = ete.encounter_type_id WHERE ete.uuid = '8d5b27bc-c2cc-11de-8d13-0010c6dffd0f' AND ee.voided = FALSE) " +
-                    " GROUP BY p.patient_id " +
-                    " HAVING p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 99606 AND oo.voided = FALSE) ";
+            return "SELECT p.patient_id , DATE_FORMAT(DATE_ADD(pe.birthdate, INTERVAL 6 WEEK), '%d.%b.%Y') FROM patient p  \n" +
+                    "  INNER JOIN obs o ON p.patient_id = o.person_id   INNER JOIN person pe ON p.patient_id = pe.person_id  \n" +
+                    "   INNER JOIN encounter e ON o.encounter_id = e.encounter_id   INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id  \n" +
+                    "    WHERE (TIMESTAMPDIFF(WEEK, pe.birthdate, CURDATE()) BETWEEN 10 AND 24) AND et.uuid='9fcfcc91-ad60-4d84-9710-11cc25258719'       \n" +
+                    "      AND p.patient_id NOT IN (SELECT ee.patient_id FROM encounter ee INNER JOIN encounter_type ete ON ee.encounter_type = ete.encounter_type_id WHERE ete.uuid = '8d5b27bc-c2cc-11de-8d13-0010c6dffd0f' AND ee.voided = FALSE)  GROUP BY p.patient_id \n" +
+                    "       HAVING p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 99606 AND oo.voided = FALSE)\n" +
+                    "       AND p.patient_id NOT IN (select person_id from person where dead !=\"false\")\n" +
+                    " AND p.patient_id NOT IN (select o.person_id from obs o where concept_id=90306 and o.voided=0)";
         }
 
         @Override
@@ -413,15 +424,14 @@ public class Flags {
     public static FlagDescriptor DUE_FOR_SECOND_DNA_PCR = new FlagDescriptor() {
         @Override
         public String criteria() {
-            return "SELECT p.patient_id , DATE_FORMAT(DATE_ADD(pe.birthdate, INTERVAL 13 MONTH), '%d.%b.%Y') FROM patient p " +
-                    "  INNER JOIN obs o ON p.patient_id = o.person_id " +
-                    "  INNER JOIN person pe ON p.patient_id = pe.person_id " +
-                    "  INNER JOIN encounter e ON o.encounter_id = e.encounter_id " +
-                    "  INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id " +
-                    "  WHERE (TIMESTAMPDIFF(MONTH, pe.birthdate, CURDATE()) BETWEEN 13 AND 14) AND et.uuid='9fcfcc91-ad60-4d84-9710-11cc25258719' " +
-                    "        AND p.patient_id NOT IN (SELECT ee.patient_id FROM encounter ee INNER JOIN encounter_type ete ON ee.encounter_type = ete.encounter_type_id WHERE ete.uuid = '8d5b27bc-c2cc-11de-8d13-0010c6dffd0f' AND ee.voided = FALSE) " +
-                    " GROUP BY p.patient_id " +
-                    " HAVING p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 99436 AND oo.voided = FALSE)";
+            return "SELECT p.patient_id , DATE_FORMAT(DATE_ADD(pe.birthdate, INTERVAL 13 MONTH), '%d.%b.%Y') FROM patient p \n" +
+                    "   INNER JOIN obs o ON p.patient_id = o.person_id   INNER JOIN person pe ON p.patient_id = pe.person_id   \n" +
+                    "   INNER JOIN encounter e ON o.encounter_id = e.encounter_id   INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id  \n" +
+                    "    WHERE (TIMESTAMPDIFF(MONTH, pe.birthdate, CURDATE()) BETWEEN 13 AND 14) AND et.uuid='9fcfcc91-ad60-4d84-9710-11cc25258719'     \n" +
+                    "        AND p.patient_id NOT IN (SELECT ee.patient_id FROM encounter ee INNER JOIN encounter_type ete ON ee.encounter_type = ete.encounter_type_id WHERE ete.uuid = '8d5b27bc-c2cc-11de-8d13-0010c6dffd0f' AND ee.voided = FALSE) \n" +
+                    "         GROUP BY p.patient_id  HAVING p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 99436 AND oo.voided = FALSE)\n" +
+                    "     AND p.patient_id NOT IN (select person_id from person where dead !=\"false\")\n" +
+                    " AND p.patient_id NOT IN (select o.person_id from obs o where concept_id=90306 and o.voided=0)";
         }
 
         @Override
@@ -458,15 +468,13 @@ public class Flags {
     public static FlagDescriptor OVERDUE_FOR_SECOND_DNA_PCR = new FlagDescriptor() {
         @Override
         public String criteria() {
-            return "SELECT p.patient_id , DATE_FORMAT(DATE_ADD(pe.birthdate, INTERVAL 13 MONTH), '%d.%b.%Y') FROM patient p " +
-                    "  INNER JOIN obs o ON p.patient_id = o.person_id " +
-                    "  INNER JOIN person pe ON p.patient_id = pe.person_id " +
-                    "  INNER JOIN encounter e ON o.encounter_id = e.encounter_id " +
-                    "  INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id " +
-                    "  WHERE (TIMESTAMPDIFF(MONTH, pe.birthdate, CURDATE()) BETWEEN 15 AND 17) AND et.uuid='9fcfcc91-ad60-4d84-9710-11cc25258719' " +
-                    "        AND p.patient_id NOT IN (SELECT ee.patient_id FROM encounter ee INNER JOIN encounter_type ete ON ee.encounter_type = ete.encounter_type_id WHERE ete.uuid = '8d5b27bc-c2cc-11de-8d13-0010c6dffd0f' AND ee.voided = FALSE) " +
-                    " GROUP BY p.patient_id " +
-                    " HAVING p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 99436 AND oo.voided = FALSE)";
+            return "SELECT p.patient_id , DATE_FORMAT(DATE_ADD(pe.birthdate, INTERVAL 13 MONTH), '%d.%b.%Y') FROM patient p  \n" +
+                    "  INNER JOIN obs o ON p.patient_id = o.person_id   INNER JOIN person pe ON p.patient_id = pe.person_id  \n" +
+                    "   INNER JOIN encounter e ON o.encounter_id = e.encounter_id   INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id \n" +
+                    "     WHERE (TIMESTAMPDIFF(MONTH, pe.birthdate, CURDATE()) BETWEEN 15 AND 17) AND et.uuid='9fcfcc91-ad60-4d84-9710-11cc25258719'  \n" +
+                    " AND p.patient_id NOT IN (SELECT ee.patient_id FROM encounter ee INNER JOIN encounter_type ete ON ee.encounter_type = ete.encounter_type_id WHERE ete.uuid = '8d5b27bc-c2cc-11de-8d13-0010c6dffd0f' AND ee.voided = FALSE)  GROUP BY p.patient_id  HAVING p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 99436 AND oo.voided = FALSE)\n" +
+                    "AND p.patient_id NOT IN (select person_id from person where dead !=\"false\")\n" +
+                    " AND p.patient_id NOT IN (select o.person_id from obs o where concept_id=90306 and o.voided=0)";
         }
 
         @Override
@@ -503,15 +511,14 @@ public class Flags {
     public static FlagDescriptor DUE_FOR_RAPID_TEST = new FlagDescriptor() {
         @Override
         public String criteria() {
-            return "SELECT p.patient_id , DATE_FORMAT(DATE_ADD(pe.birthdate, INTERVAL 18 MONTH), '%d.%b.%Y') FROM patient p " +
-                    "  INNER JOIN obs o ON p.patient_id = o.person_id " +
-                    "  INNER JOIN person pe ON p.patient_id = pe.person_id " +
-                    "  INNER JOIN encounter e ON o.encounter_id = e.encounter_id " +
-                    "  INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id " +
-                    "  WHERE TIMESTAMPDIFF(MONTH, pe.birthdate, CURDATE()) = 18 AND et.uuid='9fcfcc91-ad60-4d84-9710-11cc25258719' " +
-                    "        AND p.patient_id NOT IN (SELECT ee.patient_id FROM encounter ee INNER JOIN encounter_type ete ON ee.encounter_type = ete.encounter_type_id WHERE ete.uuid = '8d5b27bc-c2cc-11de-8d13-0010c6dffd0f' AND ee.voided = FALSE) " +
-                    " GROUP BY p.patient_id " +
-                    " HAVING p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 162879 AND oo.voided = FALSE)";
+            return "SELECT p.patient_id , DATE_FORMAT(DATE_ADD(pe.birthdate, INTERVAL 18 MONTH), '%d.%b.%Y') FROM patient p   \n" +
+                    " INNER JOIN obs o ON p.patient_id = o.person_id   INNER JOIN person pe ON p.patient_id = pe.person_id  \n" +
+                    "  INNER JOIN encounter e ON o.encounter_id = e.encounter_id   INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id  \n" +
+                    "   WHERE TIMESTAMPDIFF(MONTH, pe.birthdate, CURDATE()) = 18 AND et.uuid='9fcfcc91-ad60-4d84-9710-11cc25258719'       \n" +
+                    "     AND p.patient_id NOT IN (SELECT ee.patient_id FROM encounter ee INNER JOIN encounter_type ete ON ee.encounter_type = ete.encounter_type_id WHERE ete.uuid = '8d5b27bc-c2cc-11de-8d13-0010c6dffd0f' AND ee.voided = FALSE)  GROUP BY p.patient_id \n" +
+                    "  HAVING p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 162879 AND oo.voided = FALSE) \n" +
+                    "  AND p.patient_id NOT IN (select person_id from person where dead !=\"false\")\n" +
+                    " AND p.patient_id NOT IN (select o.person_id from obs o where concept_id=90306 and o.voided=0)";
         }
 
         @Override
@@ -548,15 +555,15 @@ public class Flags {
     public static FlagDescriptor OVERDUE_FOR_RAPID_TEST = new FlagDescriptor() {
         @Override
         public String criteria() {
-            return "SELECT p.patient_id , DATE_FORMAT(DATE_ADD(pe.birthdate, INTERVAL 18 MONTH), '%d.%b.%Y') FROM patient p " +
-                    "  INNER JOIN obs o ON p.patient_id = o.person_id " +
-                    "  INNER JOIN person pe ON p.patient_id = pe.person_id " +
-                    "  INNER JOIN encounter e ON o.encounter_id = e.encounter_id " +
-                    "  INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id " +
-                    "  WHERE (TIMESTAMPDIFF(MONTH, pe.birthdate, CURDATE()) BETWEEN 19 AND 24) AND et.uuid='9fcfcc91-ad60-4d84-9710-11cc25258719' " +
-                    "        AND p.patient_id NOT IN (SELECT ee.patient_id FROM encounter ee INNER JOIN encounter_type ete ON ee.encounter_type = ete.encounter_type_id WHERE ete.uuid = '8d5b27bc-c2cc-11de-8d13-0010c6dffd0f' AND ee.voided = FALSE) " +
-                    " GROUP BY p.patient_id " +
-                    " HAVING p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 162879 AND oo.voided = FALSE)";
+            return "SELECT p.patient_id , DATE_FORMAT(DATE_ADD(pe.birthdate, INTERVAL 18 MONTH), '%d.%b.%Y') FROM patient p \n" +
+                    "   INNER JOIN obs o ON p.patient_id = o.person_id   INNER JOIN person pe ON p.patient_id = pe.person_id  \n" +
+                    "    INNER JOIN encounter e ON o.encounter_id = e.encounter_id   INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id  \n" +
+                    "     WHERE (TIMESTAMPDIFF(MONTH, pe.birthdate, CURDATE()) BETWEEN 19 AND 24) AND et.uuid='9fcfcc91-ad60-4d84-9710-11cc25258719'         \n" +
+                    "     AND p.patient_id NOT IN (SELECT ee.patient_id FROM encounter ee INNER JOIN encounter_type ete ON ee.encounter_type = ete.encounter_type_id \n" +
+                    "     WHERE ete.uuid = '8d5b27bc-c2cc-11de-8d13-0010c6dffd0f' AND ee.voided = FALSE) \n" +
+                    "  GROUP BY p.patient_id  HAVING p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 162879 AND oo.voided = FALSE)\n" +
+                    "  AND p.patient_id NOT IN (select person_id from person where dead !=\"false\")\n" +
+                    " AND p.patient_id NOT IN (select o.person_id from obs o where concept_id=90306 and o.voided=0)";
         }
 
         @Override
@@ -598,7 +605,9 @@ public class Flags {
                     "        WHERE b.concept_id = 856 AND b.voided = 0 group by person_id) latest_vl\n" +
                     "      INNER JOIN (SELECT c.person_id as patient_id, obs_datetime, value_numeric\n" +
                     "                  FROM obs c WHERE c.concept_id = 856 AND c.voided = 0 AND c.value_numeric > 1) non_suppressed\n" +
-                    "      ON (latest_vl.person_id = non_suppressed.patient_id and latest_vl.dt = non_suppressed.obs_datetime) ";
+                    "      ON (latest_vl.person_id = non_suppressed.patient_id and latest_vl.dt = non_suppressed.obs_datetime)\n" +
+                    "AND non_suppressed.patient_id NOT IN (select person_id from person where dead !=\"false\")\n" +
+                    "AND non_suppressed.patient_id NOT IN (select o.person_id from obs o where concept_id=90306 and o.voided=0) ";
         }
 
         @Override

--- a/api/src/main/java/org/openmrs/module/aijar/metadata/core/Flags.java
+++ b/api/src/main/java/org/openmrs/module/aijar/metadata/core/Flags.java
@@ -10,13 +10,11 @@ public class Flags {
     public static FlagDescriptor DUE_FOR_FIRST_VIRAL_LOAD = new FlagDescriptor() {
         @Override
         public String criteria() {
-            return "SELECT p.patient_id, DATE_FORMAT(DATE_ADD(o.value_datetime, INTERVAL 6 MONTH), '%d.%b.%Y') FROM patient p \n" +
-                    " INNER JOIN obs o ON p.patient_id = o.person_id  INNER JOIN encounter e ON o.encounter_id = e.encounter_id  \n" +
-                    " INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id \n" +
-                    "  WHERE ((o.concept_id = 99161 AND o.voided = FALSE AND e.voided = FALSE AND ((CURRENT_DATE() BETWEEN DATE_ADD(o.value_datetime, INTERVAL 5 MONTH) AND DATE_ADD(o.value_datetime, INTERVAL 6 MONTH)) AND et.uuid='8d5b27bc-c2cc-11de-8d13-0010c6dffd0f'))) AND o.person_id \n" +
-                    "  NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 1305 AND oo.voided = FALSE)\n" +
-                    " AND p.patient_id NOT IN (select person_id from person where dead !=\"false\")\n" +
-                    " AND p.patient_id NOT IN (select o.person_id from obs o where concept_id=90306 and o.voided=0)";
+            return "SELECT p.patient_id, DATE_FORMAT(DATE_ADD(o.value_datetime, INTERVAL 6 MONTH), '%d.%b.%Y') FROM patient p " +
+                    " INNER JOIN obs o ON p.patient_id = o.person_id " +
+                    " INNER JOIN encounter e ON o.encounter_id = e.encounter_id " +
+                    " INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id " +
+                    " WHERE ((o.concept_id = 99161 AND o.voided = FALSE AND e.voided = FALSE AND ((CURRENT_DATE() BETWEEN DATE_ADD(o.value_datetime, INTERVAL 5 MONTH) AND DATE_ADD(o.value_datetime, INTERVAL 6 MONTH)) AND et.uuid='8d5b27bc-c2cc-11de-8d13-0010c6dffd0f'))) AND o.person_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 1305 AND oo.voided = FALSE)";
         }
 
         @Override
@@ -53,11 +51,10 @@ public class Flags {
     public static FlagDescriptor OVERDUE_FOR_FIRST_VIRAL_LOAD = new FlagDescriptor() {
         @Override
         public String criteria() {
-            return "SELECT p.patient_id, DATE_FORMAT(DATE_ADD(o.value_datetime, INTERVAL 6 MONTH), '%d.%b.%Y') FROM patient p  \n" +
-                    " INNER JOIN obs o ON p.patient_id = o.person_id  WHERE o.concept_id = 99161 AND o.voided = FALSE AND CURRENT_DATE() >= DATE_ADD(o.value_datetime, INTERVAL 6 MONTH)  AND o.person_id \n" +
-                    " NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 1305 AND oo.voided = FALSE)\n" +
-                    " AND p.patient_id NOT IN (select person_id from person where dead !=\"false\")\n" +
-                    " AND p.patient_id NOT IN (select o.person_id from obs o where concept_id=90306 and o.voided=0)";
+            return "SELECT p.patient_id, DATE_FORMAT(DATE_ADD(o.value_datetime, INTERVAL 6 MONTH), '%d.%b.%Y') FROM patient p " +
+                    " INNER JOIN obs o ON p.patient_id = o.person_id " +
+                    " WHERE o.concept_id = 99161 AND o.voided = FALSE AND CURRENT_DATE() >= DATE_ADD(o.value_datetime, INTERVAL 6 MONTH) " +
+                    " AND o.person_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 1305 AND oo.voided = FALSE)";
         }
 
         @Override
@@ -94,11 +91,12 @@ public class Flags {
     public static FlagDescriptor DUE_FOR_ROUTINE_VIRAL_LOAD = new FlagDescriptor() {
         @Override
         public String criteria() {
-            return " SELECT p.patient_id, DATE_FORMAT(IF(TIMESTAMPDIFF(YEAR, pe.birthdate, CURDATE()) < 16, DATE_ADD(MAX(o.value_datetime), INTERVAL 6 MONTH), DATE_ADD(MAX(o.value_datetime), INTERVAL 12 MONTH)), '%d.%b.%Y') FROM patient p  \n" +
-                    "  INNER JOIN obs o ON p.patient_id = o.person_id   INNER JOIN person pe ON o.person_id = pe.person_id  WHERE o.concept_id = 163023 AND o.voided = FALSE  GROUP BY pe.person_id, pe.birthdate \n" +
-                    "   HAVING DATEDIFF(IF(TIMESTAMPDIFF(YEAR, pe.birthdate, CURDATE()) < 16, DATE_ADD(MAX(o.value_datetime), INTERVAL 6 MONTH), DATE_ADD(MAX(o.value_datetime), INTERVAL 12 MONTH)), CURRENT_DATE()) BETWEEN 0 AND 30\n" +
-                    "   AND p.patient_id NOT IN (select person_id from person where dead !=\"false\")\n" +
-                    " AND p.patient_id NOT IN (select o.person_id from obs o where concept_id=90306 and o.voided=0)";
+            return "SELECT p.patient_id, DATE_FORMAT(IF(TIMESTAMPDIFF(YEAR, pe.birthdate, CURDATE()) < 16, DATE_ADD(MAX(o.value_datetime), INTERVAL 6 MONTH), DATE_ADD(MAX(o.value_datetime), INTERVAL 12 MONTH)), '%d.%b.%Y') FROM patient p " +
+                    "  INNER JOIN obs o ON p.patient_id = o.person_id " +
+                    "  INNER JOIN person pe ON o.person_id = pe.person_id " +
+                    " WHERE o.concept_id = 163023 AND o.voided = FALSE " +
+                    " GROUP BY pe.person_id, pe.birthdate " +
+                    " HAVING DATEDIFF(IF(TIMESTAMPDIFF(YEAR, pe.birthdate, CURDATE()) < 16, DATE_ADD(MAX(o.value_datetime), INTERVAL 6 MONTH), DATE_ADD(MAX(o.value_datetime), INTERVAL 12 MONTH)), CURRENT_DATE()) BETWEEN 0 AND 30";
         }
 
         @Override
@@ -135,11 +133,12 @@ public class Flags {
     public static FlagDescriptor OVERDUE_FOR_ROUTINE_VIRAL_LOAD = new FlagDescriptor() {
         @Override
         public String criteria() {
-            return "SELECT p.patient_id, DATE_FORMAT(IF(TIMESTAMPDIFF(YEAR, pe.birthdate, CURDATE()) < 16, DATE_ADD(MAX(o.value_datetime), INTERVAL 6 MONTH), DATE_ADD(MAX(o.value_datetime), INTERVAL 12 MONTH)), '%d.%b.%Y') FROM patient p  \n" +
-                    "  INNER JOIN obs o ON p.patient_id = o.person_id   INNER JOIN person pe ON o.person_id = pe.person_id  WHERE o.concept_id = 163023 AND o.voided = FALSE  GROUP BY pe.person_id, pe.birthdate \n" +
-                    "   HAVING CURRENT_DATE() > IF(TIMESTAMPDIFF(YEAR, pe.birthdate, CURDATE()) < 16, DATE_ADD(MAX(o.value_datetime), INTERVAL 6 MONTH), DATE_ADD(MAX(o.value_datetime), INTERVAL 12 MONTH))\n" +
-                    "   AND p.patient_id NOT IN (select person_id from person where dead !=\"false\")\n" +
-                    " AND p.patient_id NOT IN (select o.person_id from obs o where concept_id=90306 and o.voided=0)";
+            return "SELECT p.patient_id, DATE_FORMAT(IF(TIMESTAMPDIFF(YEAR, pe.birthdate, CURDATE()) < 16, DATE_ADD(MAX(o.value_datetime), INTERVAL 6 MONTH), DATE_ADD(MAX(o.value_datetime), INTERVAL 12 MONTH)), '%d.%b.%Y') FROM patient p " +
+                    "  INNER JOIN obs o ON p.patient_id = o.person_id " +
+                    "  INNER JOIN person pe ON o.person_id = pe.person_id " +
+                    " WHERE o.concept_id = 163023 AND o.voided = FALSE " +
+                    " GROUP BY pe.person_id, pe.birthdate " +
+                    " HAVING CURRENT_DATE() > IF(TIMESTAMPDIFF(YEAR, pe.birthdate, CURDATE()) < 16, DATE_ADD(MAX(o.value_datetime), INTERVAL 6 MONTH), DATE_ADD(MAX(o.value_datetime), INTERVAL 12 MONTH))";
         }
 
         @Override
@@ -176,10 +175,7 @@ public class Flags {
     public static FlagDescriptor UPCOMING_APPOINTMENT = new FlagDescriptor() {
         @Override
         public String criteria() {
-            return "SELECT p.patient_id, DATE_FORMAT(MAX(o.value_datetime), '%d.%b.%Y') FROM patient p \n" +
-                    " INNER JOIN obs o ON p.patient_id = o.person_id WHERE o.concept_id = 5096 AND o.voided = FALSE  GROUP BY o.person_id HAVING MAX(o.value_datetime) >= CURRENT_DATE()\n" +
-                    " AND p.patient_id NOT IN (select person_id from person where dead !=\"false\")\n" +
-                    " AND p.patient_id NOT IN (select o.person_id from obs o where concept_id=90306 and o.voided=0)";
+            return "SELECT p.patient_id, DATE_FORMAT(MAX(o.value_datetime), '%d.%b.%Y') FROM patient p INNER JOIN obs o ON p.patient_id = o.person_id WHERE o.concept_id = 5096 AND o.voided = FALSE  GROUP BY o.person_id HAVING MAX(o.value_datetime) >= CURRENT_DATE()";
         }
 
         @Override
@@ -216,10 +212,7 @@ public class Flags {
     public static FlagDescriptor MISSED_APPOINTMENT = new FlagDescriptor() {
         @Override
         public String criteria() {
-            return " SELECT p.patient_id, DATE_FORMAT(MAX(o.value_datetime), '%d.%b.%Y') FROM patient p\n" +
-                    "  INNER JOIN obs o ON p.patient_id = o.person_id WHERE o.concept_id = 5096 AND o.voided = FALSE GROUP BY o.person_id HAVING MAX(o.value_datetime) BETWEEN DATE_SUB(CURRENT_DATE(), INTERVAL 29 DAY) AND DATE_SUB(CURRENT_DATE(), INTERVAL 7 DAY)\n" +
-                    " AND p.patient_id NOT IN (select person_id from person where dead !=\"false\")\n" +
-                    " AND p.patient_id NOT IN (select o.person_id from obs o where concept_id=90306 and o.voided=0)";
+            return "SELECT p.patient_id, DATE_FORMAT(MAX(o.value_datetime), '%d.%b.%Y') FROM patient p INNER JOIN obs o ON p.patient_id = o.person_id WHERE o.concept_id = 5096 AND o.voided = FALSE GROUP BY o.person_id HAVING MAX(o.value_datetime) BETWEEN DATE_SUB(CURRENT_DATE(), INTERVAL 29 DAY) AND DATE_SUB(CURRENT_DATE(), INTERVAL 7 DAY)";
         }
 
         @Override
@@ -256,10 +249,7 @@ public class Flags {
     public static FlagDescriptor PATIENT_LOST = new FlagDescriptor() {
         @Override
         public String criteria() {
-            return " SELECT p.patient_id, DATE_FORMAT(DATE_ADD(MAX(o.value_datetime), INTERVAL 30 DAY), '%d.%b.%Y') FROM patient p\n" +
-                    "  INNER JOIN obs o ON p.patient_id = o.person_id WHERE o.concept_id = 5096 AND o.voided = FALSE GROUP BY o.person_id HAVING MAX(o.value_datetime) BETWEEN DATE_SUB(CURRENT_DATE(), INTERVAL 89 DAY) AND DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY)\n" +
-                    " AND p.patient_id NOT IN (select person_id from person where dead !=\"false\")\n" +
-                    " AND p.patient_id NOT IN (select o.person_id from obs o where concept_id=90306 and o.voided=0)";
+            return "SELECT p.patient_id, DATE_FORMAT(DATE_ADD(MAX(o.value_datetime), INTERVAL 30 DAY), '%d.%b.%Y') FROM patient p INNER JOIN obs o ON p.patient_id = o.person_id WHERE o.concept_id = 5096 AND o.voided = FALSE GROUP BY o.person_id HAVING MAX(o.value_datetime) BETWEEN DATE_SUB(CURRENT_DATE(), INTERVAL 89 DAY) AND DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY)";
         }
 
         @Override
@@ -296,10 +286,12 @@ public class Flags {
     public static FlagDescriptor PATIENT_LOST_TO_FOLLOWUP = new FlagDescriptor() {
         @Override
         public String criteria() {
-            return "SELECT p.patient_id, DATE_FORMAT(DATE_ADD(MAX(o.value_datetime), INTERVAL 90 DAY), '%d.%b.%Y') FROM patient p \n" +
-                    "INNER JOIN obs o ON p.patient_id = o.person_id WHERE o.concept_id = 5096 AND o.voided = FALSE GROUP BY o.person_id HAVING MAX(o.value_datetime) <= DATE_SUB(CURRENT_DATE(), INTERVAL 90 DAY)\n" +
-                    "AND p.patient_id NOT IN (select person_id from person where dead !=\"false\")\n" +
-                    "AND p.patient_id NOT IN (select o.person_id from obs o where concept_id=90306 and o.voided=0)";
+            return "SELECT p.patient_id, DATE_FORMAT(DATE_ADD(MAX(o.value_datetime), INTERVAL 90 DAY), '%d.%b.%Y') FROM patient p\n" +
+                    "                    INNER JOIN obs o ON p.patient_id = o.person_id \n" +
+                    "                    INNER JOIN person pp ON pp.person_id=p.patient_id \n" +
+                    "                    WHERE  pp.dead =false and pp.voided=false AND o.concept_id = 5096 AND  o.voided = FALSE GROUP BY o.person_id \n" +
+                    "                    HAVING MAX(o.value_datetime) <= DATE_SUB(CURRENT_DATE(), INTERVAL 90 DAY)\n" +
+                    "                    AND p.patient_id NOT IN (select o.person_id from obs o where concept_id=90306 and o.voided=false)";
         }
 
         @Override
@@ -336,14 +328,15 @@ public class Flags {
     public static FlagDescriptor DUE_FOR_FIRST_DNA_PCR = new FlagDescriptor() {
         @Override
         public String criteria() {
-            return " SELECT p.patient_id , DATE_FORMAT(DATE_ADD(pe.birthdate, INTERVAL 6 WEEK), '%d.%b.%Y') FROM patient p \n" +
-                    "   INNER JOIN obs o ON p.patient_id = o.person_id   INNER JOIN person pe ON p.patient_id = pe.person_id   \n" +
-                    "   INNER JOIN encounter e ON o.encounter_id = e.encounter_id \n" +
-                    "   INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id   WHERE (TIMESTAMPDIFF(WEEK, pe.birthdate, CURDATE()) BETWEEN 6 AND 9) AND et.uuid='9fcfcc91-ad60-4d84-9710-11cc25258719'   \n" +
-                    "         AND p.patient_id NOT IN (SELECT ee.patient_id FROM encounter ee INNER JOIN encounter_type ete ON ee.encounter_type = ete.encounter_type_id WHERE ete.uuid = '8d5b27bc-c2cc-11de-8d13-0010c6dffd0f' AND ee.voided = FALSE)  GROUP BY p.patient_id  \n" +
-                    "         HAVING p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 99606 AND oo.voided = FALSE)\n" +
-                    "AND p.patient_id NOT IN (select person_id from person where dead !=\"false\")\n" +
-                    " AND p.patient_id NOT IN (select o.person_id from obs o where concept_id=90306 and o.voided=0)";
+            return "SELECT p.patient_id , DATE_FORMAT(DATE_ADD(pe.birthdate, INTERVAL 6 WEEK), '%d.%b.%Y') FROM patient p " +
+                    "  INNER JOIN obs o ON p.patient_id = o.person_id " +
+                    "  INNER JOIN person pe ON p.patient_id = pe.person_id " +
+                    "  INNER JOIN encounter e ON o.encounter_id = e.encounter_id " +
+                    "  INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id " +
+                    "  WHERE (TIMESTAMPDIFF(WEEK, pe.birthdate, CURDATE()) BETWEEN 6 AND 9) AND et.uuid='9fcfcc91-ad60-4d84-9710-11cc25258719' " +
+                    "        AND p.patient_id NOT IN (SELECT ee.patient_id FROM encounter ee INNER JOIN encounter_type ete ON ee.encounter_type = ete.encounter_type_id WHERE ete.uuid = '8d5b27bc-c2cc-11de-8d13-0010c6dffd0f' AND ee.voided = FALSE) " +
+                    " GROUP BY p.patient_id " +
+                    " HAVING p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 99606 AND oo.voided = FALSE) ";
         }
 
         @Override
@@ -380,14 +373,15 @@ public class Flags {
     public static FlagDescriptor OVERDUE_FOR_FIRST_DNA_PCR = new FlagDescriptor() {
         @Override
         public String criteria() {
-            return "SELECT p.patient_id , DATE_FORMAT(DATE_ADD(pe.birthdate, INTERVAL 6 WEEK), '%d.%b.%Y') FROM patient p  \n" +
-                    "  INNER JOIN obs o ON p.patient_id = o.person_id   INNER JOIN person pe ON p.patient_id = pe.person_id  \n" +
-                    "   INNER JOIN encounter e ON o.encounter_id = e.encounter_id   INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id  \n" +
-                    "    WHERE (TIMESTAMPDIFF(WEEK, pe.birthdate, CURDATE()) BETWEEN 10 AND 24) AND et.uuid='9fcfcc91-ad60-4d84-9710-11cc25258719'       \n" +
-                    "      AND p.patient_id NOT IN (SELECT ee.patient_id FROM encounter ee INNER JOIN encounter_type ete ON ee.encounter_type = ete.encounter_type_id WHERE ete.uuid = '8d5b27bc-c2cc-11de-8d13-0010c6dffd0f' AND ee.voided = FALSE)  GROUP BY p.patient_id \n" +
-                    "       HAVING p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 99606 AND oo.voided = FALSE)\n" +
-                    "       AND p.patient_id NOT IN (select person_id from person where dead !=\"false\")\n" +
-                    " AND p.patient_id NOT IN (select o.person_id from obs o where concept_id=90306 and o.voided=0)";
+            return "SELECT p.patient_id , DATE_FORMAT(DATE_ADD(pe.birthdate, INTERVAL 6 WEEK), '%d.%b.%Y') FROM patient p " +
+                    "  INNER JOIN obs o ON p.patient_id = o.person_id " +
+                    "  INNER JOIN person pe ON p.patient_id = pe.person_id " +
+                    "  INNER JOIN encounter e ON o.encounter_id = e.encounter_id " +
+                    "  INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id " +
+                    "  WHERE (TIMESTAMPDIFF(WEEK, pe.birthdate, CURDATE()) BETWEEN 10 AND 24) AND et.uuid='9fcfcc91-ad60-4d84-9710-11cc25258719' " +
+                    "        AND p.patient_id NOT IN (SELECT ee.patient_id FROM encounter ee INNER JOIN encounter_type ete ON ee.encounter_type = ete.encounter_type_id WHERE ete.uuid = '8d5b27bc-c2cc-11de-8d13-0010c6dffd0f' AND ee.voided = FALSE) " +
+                    " GROUP BY p.patient_id " +
+                    " HAVING p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 99606 AND oo.voided = FALSE) ";
         }
 
         @Override
@@ -424,14 +418,15 @@ public class Flags {
     public static FlagDescriptor DUE_FOR_SECOND_DNA_PCR = new FlagDescriptor() {
         @Override
         public String criteria() {
-            return "SELECT p.patient_id , DATE_FORMAT(DATE_ADD(pe.birthdate, INTERVAL 13 MONTH), '%d.%b.%Y') FROM patient p \n" +
-                    "   INNER JOIN obs o ON p.patient_id = o.person_id   INNER JOIN person pe ON p.patient_id = pe.person_id   \n" +
-                    "   INNER JOIN encounter e ON o.encounter_id = e.encounter_id   INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id  \n" +
-                    "    WHERE (TIMESTAMPDIFF(MONTH, pe.birthdate, CURDATE()) BETWEEN 13 AND 14) AND et.uuid='9fcfcc91-ad60-4d84-9710-11cc25258719'     \n" +
-                    "        AND p.patient_id NOT IN (SELECT ee.patient_id FROM encounter ee INNER JOIN encounter_type ete ON ee.encounter_type = ete.encounter_type_id WHERE ete.uuid = '8d5b27bc-c2cc-11de-8d13-0010c6dffd0f' AND ee.voided = FALSE) \n" +
-                    "         GROUP BY p.patient_id  HAVING p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 99436 AND oo.voided = FALSE)\n" +
-                    "     AND p.patient_id NOT IN (select person_id from person where dead !=\"false\")\n" +
-                    " AND p.patient_id NOT IN (select o.person_id from obs o where concept_id=90306 and o.voided=0)";
+            return "SELECT p.patient_id , DATE_FORMAT(DATE_ADD(pe.birthdate, INTERVAL 13 MONTH), '%d.%b.%Y') FROM patient p " +
+                    "  INNER JOIN obs o ON p.patient_id = o.person_id " +
+                    "  INNER JOIN person pe ON p.patient_id = pe.person_id " +
+                    "  INNER JOIN encounter e ON o.encounter_id = e.encounter_id " +
+                    "  INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id " +
+                    "  WHERE (TIMESTAMPDIFF(MONTH, pe.birthdate, CURDATE()) BETWEEN 13 AND 14) AND et.uuid='9fcfcc91-ad60-4d84-9710-11cc25258719' " +
+                    "        AND p.patient_id NOT IN (SELECT ee.patient_id FROM encounter ee INNER JOIN encounter_type ete ON ee.encounter_type = ete.encounter_type_id WHERE ete.uuid = '8d5b27bc-c2cc-11de-8d13-0010c6dffd0f' AND ee.voided = FALSE) " +
+                    " GROUP BY p.patient_id " +
+                    " HAVING p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 99436 AND oo.voided = FALSE)";
         }
 
         @Override
@@ -468,13 +463,15 @@ public class Flags {
     public static FlagDescriptor OVERDUE_FOR_SECOND_DNA_PCR = new FlagDescriptor() {
         @Override
         public String criteria() {
-            return "SELECT p.patient_id , DATE_FORMAT(DATE_ADD(pe.birthdate, INTERVAL 13 MONTH), '%d.%b.%Y') FROM patient p  \n" +
-                    "  INNER JOIN obs o ON p.patient_id = o.person_id   INNER JOIN person pe ON p.patient_id = pe.person_id  \n" +
-                    "   INNER JOIN encounter e ON o.encounter_id = e.encounter_id   INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id \n" +
-                    "     WHERE (TIMESTAMPDIFF(MONTH, pe.birthdate, CURDATE()) BETWEEN 15 AND 17) AND et.uuid='9fcfcc91-ad60-4d84-9710-11cc25258719'  \n" +
-                    " AND p.patient_id NOT IN (SELECT ee.patient_id FROM encounter ee INNER JOIN encounter_type ete ON ee.encounter_type = ete.encounter_type_id WHERE ete.uuid = '8d5b27bc-c2cc-11de-8d13-0010c6dffd0f' AND ee.voided = FALSE)  GROUP BY p.patient_id  HAVING p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 99436 AND oo.voided = FALSE)\n" +
-                    "AND p.patient_id NOT IN (select person_id from person where dead !=\"false\")\n" +
-                    " AND p.patient_id NOT IN (select o.person_id from obs o where concept_id=90306 and o.voided=0)";
+            return "SELECT p.patient_id , DATE_FORMAT(DATE_ADD(pe.birthdate, INTERVAL 13 MONTH), '%d.%b.%Y') FROM patient p " +
+                    "  INNER JOIN obs o ON p.patient_id = o.person_id " +
+                    "  INNER JOIN person pe ON p.patient_id = pe.person_id " +
+                    "  INNER JOIN encounter e ON o.encounter_id = e.encounter_id " +
+                    "  INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id " +
+                    "  WHERE (TIMESTAMPDIFF(MONTH, pe.birthdate, CURDATE()) BETWEEN 15 AND 17) AND et.uuid='9fcfcc91-ad60-4d84-9710-11cc25258719' " +
+                    "        AND p.patient_id NOT IN (SELECT ee.patient_id FROM encounter ee INNER JOIN encounter_type ete ON ee.encounter_type = ete.encounter_type_id WHERE ete.uuid = '8d5b27bc-c2cc-11de-8d13-0010c6dffd0f' AND ee.voided = FALSE) " +
+                    " GROUP BY p.patient_id " +
+                    " HAVING p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 99436 AND oo.voided = FALSE)";
         }
 
         @Override
@@ -511,14 +508,15 @@ public class Flags {
     public static FlagDescriptor DUE_FOR_RAPID_TEST = new FlagDescriptor() {
         @Override
         public String criteria() {
-            return "SELECT p.patient_id , DATE_FORMAT(DATE_ADD(pe.birthdate, INTERVAL 18 MONTH), '%d.%b.%Y') FROM patient p   \n" +
-                    " INNER JOIN obs o ON p.patient_id = o.person_id   INNER JOIN person pe ON p.patient_id = pe.person_id  \n" +
-                    "  INNER JOIN encounter e ON o.encounter_id = e.encounter_id   INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id  \n" +
-                    "   WHERE TIMESTAMPDIFF(MONTH, pe.birthdate, CURDATE()) = 18 AND et.uuid='9fcfcc91-ad60-4d84-9710-11cc25258719'       \n" +
-                    "     AND p.patient_id NOT IN (SELECT ee.patient_id FROM encounter ee INNER JOIN encounter_type ete ON ee.encounter_type = ete.encounter_type_id WHERE ete.uuid = '8d5b27bc-c2cc-11de-8d13-0010c6dffd0f' AND ee.voided = FALSE)  GROUP BY p.patient_id \n" +
-                    "  HAVING p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 162879 AND oo.voided = FALSE) \n" +
-                    "  AND p.patient_id NOT IN (select person_id from person where dead !=\"false\")\n" +
-                    " AND p.patient_id NOT IN (select o.person_id from obs o where concept_id=90306 and o.voided=0)";
+            return "SELECT p.patient_id , DATE_FORMAT(DATE_ADD(pe.birthdate, INTERVAL 18 MONTH), '%d.%b.%Y') FROM patient p " +
+                    "  INNER JOIN obs o ON p.patient_id = o.person_id " +
+                    "  INNER JOIN person pe ON p.patient_id = pe.person_id " +
+                    "  INNER JOIN encounter e ON o.encounter_id = e.encounter_id " +
+                    "  INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id " +
+                    "  WHERE TIMESTAMPDIFF(MONTH, pe.birthdate, CURDATE()) = 18 AND et.uuid='9fcfcc91-ad60-4d84-9710-11cc25258719' " +
+                    "        AND p.patient_id NOT IN (SELECT ee.patient_id FROM encounter ee INNER JOIN encounter_type ete ON ee.encounter_type = ete.encounter_type_id WHERE ete.uuid = '8d5b27bc-c2cc-11de-8d13-0010c6dffd0f' AND ee.voided = FALSE) " +
+                    " GROUP BY p.patient_id " +
+                    " HAVING p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 162879 AND oo.voided = FALSE)";
         }
 
         @Override
@@ -555,15 +553,15 @@ public class Flags {
     public static FlagDescriptor OVERDUE_FOR_RAPID_TEST = new FlagDescriptor() {
         @Override
         public String criteria() {
-            return "SELECT p.patient_id , DATE_FORMAT(DATE_ADD(pe.birthdate, INTERVAL 18 MONTH), '%d.%b.%Y') FROM patient p \n" +
-                    "   INNER JOIN obs o ON p.patient_id = o.person_id   INNER JOIN person pe ON p.patient_id = pe.person_id  \n" +
-                    "    INNER JOIN encounter e ON o.encounter_id = e.encounter_id   INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id  \n" +
-                    "     WHERE (TIMESTAMPDIFF(MONTH, pe.birthdate, CURDATE()) BETWEEN 19 AND 24) AND et.uuid='9fcfcc91-ad60-4d84-9710-11cc25258719'         \n" +
-                    "     AND p.patient_id NOT IN (SELECT ee.patient_id FROM encounter ee INNER JOIN encounter_type ete ON ee.encounter_type = ete.encounter_type_id \n" +
-                    "     WHERE ete.uuid = '8d5b27bc-c2cc-11de-8d13-0010c6dffd0f' AND ee.voided = FALSE) \n" +
-                    "  GROUP BY p.patient_id  HAVING p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 162879 AND oo.voided = FALSE)\n" +
-                    "  AND p.patient_id NOT IN (select person_id from person where dead !=\"false\")\n" +
-                    " AND p.patient_id NOT IN (select o.person_id from obs o where concept_id=90306 and o.voided=0)";
+            return "SELECT p.patient_id , DATE_FORMAT(DATE_ADD(pe.birthdate, INTERVAL 18 MONTH), '%d.%b.%Y') FROM patient p " +
+                    "  INNER JOIN obs o ON p.patient_id = o.person_id " +
+                    "  INNER JOIN person pe ON p.patient_id = pe.person_id " +
+                    "  INNER JOIN encounter e ON o.encounter_id = e.encounter_id " +
+                    "  INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id " +
+                    "  WHERE (TIMESTAMPDIFF(MONTH, pe.birthdate, CURDATE()) BETWEEN 19 AND 24) AND et.uuid='9fcfcc91-ad60-4d84-9710-11cc25258719' " +
+                    "        AND p.patient_id NOT IN (SELECT ee.patient_id FROM encounter ee INNER JOIN encounter_type ete ON ee.encounter_type = ete.encounter_type_id WHERE ete.uuid = '8d5b27bc-c2cc-11de-8d13-0010c6dffd0f' AND ee.voided = FALSE) " +
+                    " GROUP BY p.patient_id " +
+                    " HAVING p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 162879 AND oo.voided = FALSE)";
         }
 
         @Override
@@ -605,9 +603,7 @@ public class Flags {
                     "        WHERE b.concept_id = 856 AND b.voided = 0 group by person_id) latest_vl\n" +
                     "      INNER JOIN (SELECT c.person_id as patient_id, obs_datetime, value_numeric\n" +
                     "                  FROM obs c WHERE c.concept_id = 856 AND c.voided = 0 AND c.value_numeric > 1) non_suppressed\n" +
-                    "      ON (latest_vl.person_id = non_suppressed.patient_id and latest_vl.dt = non_suppressed.obs_datetime)\n" +
-                    "AND non_suppressed.patient_id NOT IN (select person_id from person where dead !=\"false\")\n" +
-                    "AND non_suppressed.patient_id NOT IN (select o.person_id from obs o where concept_id=90306 and o.voided=0) ";
+                    "      ON (latest_vl.person_id = non_suppressed.patient_id and latest_vl.dt = non_suppressed.obs_datetime) ";
         }
 
         @Override

--- a/api/src/main/java/org/openmrs/module/aijar/metadata/core/Flags.java
+++ b/api/src/main/java/org/openmrs/module/aijar/metadata/core/Flags.java
@@ -13,7 +13,7 @@ public class Flags {
             return "SELECT p.patient_id, DATE_FORMAT(DATE_ADD(o.value_datetime, INTERVAL 6 MONTH), '%d.%b.%Y') FROM patient p \n" +
                     " INNER JOIN obs o ON p.patient_id = o.person_id  INNER JOIN encounter e ON o.encounter_id = e.encounter_id  \n" +
                     " INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id \n" +
-                    " INNER JOIN person pp ON pp.person_id=p.patient_id  WHERE  pp.dead =false and pp.voided=false\n" +
+                    " INNER JOIN person pp ON pp.person_id=p.patient_id  WHERE  pp.dead =false \n" +
                     "  AND ((o.concept_id = 99161 AND o.voided = FALSE AND e.voided = FALSE AND ((CURRENT_DATE() BETWEEN DATE_ADD(o.value_datetime, INTERVAL 5 MONTH) AND DATE_ADD(o.value_datetime, INTERVAL 6 MONTH)) AND et.uuid='8d5b27bc-c2cc-11de-8d13-0010c6dffd0f'))) AND o.person_id \n" +
                     "  NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 1305 AND oo.voided = FALSE)\n" +
                     " AND p.patient_id NOT IN (select o.person_id from obs o where concept_id=90306 and o.voided=FALSE)";
@@ -55,7 +55,7 @@ public class Flags {
         public String criteria() {
             return "SELECT p.patient_id, DATE_FORMAT(DATE_ADD(o.value_datetime, INTERVAL 6 MONTH), '%d.%b.%Y') FROM patient p\n" +
                     "                     INNER JOIN obs o ON p.patient_id = o.person_id\n" +
-                    "                     INNER JOIN person pp ON pp.person_id = p.patient_id WHERE pp.dead = FALSE AND pp.voided = false \n" +
+                    "                     INNER JOIN person pp ON pp.person_id = p.patient_id WHERE pp.dead = FALSE \n" +
                     "                     AND  o.concept_id = 99161 AND o.voided = FALSE AND CURRENT_DATE() >= DATE_ADD(o.value_datetime, INTERVAL 6 MONTH)\n" +
                     "                     AND o.person_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 1305 AND oo.voided = FALSE)\n" +
                     "                     AND p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 90306 AND oo.voided = FALSE)";
@@ -98,7 +98,7 @@ public class Flags {
             return "SELECT p.patient_id, DATE_FORMAT(IF(TIMESTAMPDIFF(YEAR, pe.birthdate, CURDATE()) < 16, DATE_ADD(MAX(o.value_datetime), INTERVAL 6 MONTH), DATE_ADD(MAX(o.value_datetime), INTERVAL 12 MONTH)), '%d.%b.%Y') FROM patient p\n" +
                     "INNER JOIN obs o ON p.patient_id = o.person_id \n" +
                     "INNER JOIN person pe ON o.person_id = pe.person_id \n" +
-                    "WHERE pe.dead=FALSE AND pe.voided=FALSE\n" +
+                    "WHERE pe.dead=FALSE\n" +
                     "AND o.concept_id = 163023 AND o.voided = FALSE \n" +
                     "GROUP BY pe.person_id, pe.birthdate \n" +
                     "HAVING DATEDIFF(IF(TIMESTAMPDIFF(YEAR, pe.birthdate, CURDATE()) < 16, DATE_ADD(MAX(o.value_datetime), INTERVAL 6 MONTH), DATE_ADD(MAX(o.value_datetime), INTERVAL 12 MONTH)), CURRENT_DATE()) BETWEEN 0 AND 30\n" +
@@ -142,7 +142,7 @@ public class Flags {
             return "SELECT p.patient_id, DATE_FORMAT(IF(TIMESTAMPDIFF(YEAR, pe.birthdate, CURDATE()) < 16, DATE_ADD(MAX(o.value_datetime), INTERVAL 6 MONTH), DATE_ADD(MAX(o.value_datetime), INTERVAL 12 MONTH)), '%d.%b.%Y') FROM patient p \n" +
                     "INNER JOIN obs o ON p.patient_id = o.person_id\n" +
                     "INNER JOIN person pe ON o.person_id = pe.person_id \n" +
-                    " WHERE pe.dead=FALSE AND pe.voided=FALSE\n" +
+                    " WHERE pe.dead=FALSE\n" +
                     "AND  o.concept_id = 163023 AND o.voided = FALSE\n" +
                     "GROUP BY pe.person_id, pe.birthdate \n" +
                     "HAVING CURRENT_DATE() > IF(TIMESTAMPDIFF(YEAR, pe.birthdate, CURDATE()) < 16, DATE_ADD(MAX(o.value_datetime), INTERVAL 6 MONTH), DATE_ADD(MAX(o.value_datetime), INTERVAL 12 MONTH))\n" +
@@ -186,7 +186,7 @@ public class Flags {
             return "SELECT p.patient_id, DATE_FORMAT(MAX(o.value_datetime), '%d.%b.%Y') FROM patient p \n" +
                     "INNER JOIN obs o ON p.patient_id = o.person_id \n" +
                     "INNER JOIN person pe on pe.person_id=p.patient_id\n" +
-                    " WHERE pe.dead=FALSE AND pe.voided=FALSE\n" +
+                    " WHERE pe.dead=FALSE\n" +
                     "AND  o.concept_id = 5096 AND o.voided = FALSE  GROUP BY o.person_id HAVING MAX(o.value_datetime) >= CURRENT_DATE()\n" +
                     "AND p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 90306 AND oo.voided = FALSE)";
         }
@@ -229,7 +229,7 @@ public class Flags {
                     "FROM patient p\n" +
                     " INNER JOIN obs o ON p.patient_id = o.person_id \n" +
                     " INNER JOIN person pe on pe.person_id=p.patient_id\n" +
-                    " WHERE pe.dead=FALSE AND pe.voided=FALSE\n" +
+                    " WHERE pe.dead=FALSE\n" +
                     " AND o.concept_id = 5096 AND o.voided = FALSE GROUP BY o.person_id \n" +
                     " HAVING MAX(o.value_datetime) BETWEEN DATE_SUB(CURRENT_DATE(), INTERVAL 29 DAY) AND DATE_SUB(CURRENT_DATE(), INTERVAL 7 DAY)\n" +
                     " AND p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 90306 AND oo.voided = FALSE)";
@@ -272,7 +272,7 @@ public class Flags {
             return "SELECT p.patient_id, DATE_FORMAT(DATE_ADD(MAX(o.value_datetime), INTERVAL 30 DAY), '%d.%b.%Y') FROM patient p\n" +
                     "   INNER JOIN obs o ON p.patient_id = o.person_id\n" +
                     "   INNER JOIN person pe on pe.person_id=p.patient_id\n" +
-                    "   WHERE pe.dead=FALSE AND pe.voided=FALSE\n" +
+                    "   WHERE pe.dead=FALSE \n" +
                     "    AND o.concept_id = 5096 AND o.voided = FALSE GROUP BY o.person_id \n" +
                     "   HAVING MAX(o.value_datetime) BETWEEN DATE_SUB(CURRENT_DATE(), INTERVAL 89 DAY) AND DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY)\n" +
                     "   AND p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 90306 AND oo.voided = FALSE)";
@@ -315,7 +315,7 @@ public class Flags {
             return "SELECT p.patient_id, DATE_FORMAT(DATE_ADD(MAX(o.value_datetime), INTERVAL 90 DAY), '%d.%b.%Y') FROM patient p\n" +
                     " INNER JOIN obs o ON p.patient_id = o.person_id \n" +
                     "INNER JOIN person pp ON pp.person_id=p.patient_id \n" +
-                    "WHERE  pp.dead =false and pp.voided=false AND o.concept_id = 5096 AND  o.voided = FALSE GROUP BY o.person_id \n" +
+                    "WHERE  pp.dead =false  AND o.concept_id = 5096 AND  o.voided = FALSE GROUP BY o.person_id \n" +
                     "HAVING MAX(o.value_datetime) <= DATE_SUB(CURRENT_DATE(), INTERVAL 90 DAY)\n" +
                     "AND p.patient_id NOT IN (select o.person_id from obs o where concept_id=90306 and o.voided=false)";
         }
@@ -359,7 +359,7 @@ public class Flags {
                     " INNER JOIN person pe ON p.patient_id = pe.person_id \n" +
                     " INNER JOIN encounter e ON o.encounter_id = e.encounter_id \n" +
                     " INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id \n" +
-                    " WHERE pe.dead=FALSE AND pe.voided=FALSE  \n" +
+                    " WHERE pe.dead=FALSE \n" +
                     " AND (TIMESTAMPDIFF(WEEK, pe.birthdate, CURDATE()) BETWEEN 6 AND 9) AND et.uuid='9fcfcc91-ad60-4d84-9710-11cc25258719'\n" +
                     " AND p.patient_id NOT IN (SELECT ee.patient_id FROM encounter ee INNER JOIN encounter_type ete ON ee.encounter_type = ete.encounter_type_id WHERE ete.uuid = '8d5b27bc-c2cc-11de-8d13-0010c6dffd0f' AND ee.voided = FALSE)  GROUP BY p.patient_id \n" +
                     " HAVING p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 99606 AND oo.voided = FALSE)\n" +
@@ -405,7 +405,7 @@ public class Flags {
                     "  INNER JOIN person pe ON p.patient_id = pe.person_id \n" +
                     "    INNER JOIN encounter e ON o.encounter_id = e.encounter_id  \n" +
                     "     INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id \n" +
-                    "WHERE pe.dead=FALSE AND pe.voided=FALSE \n" +
+                    "WHERE pe.dead=FALSE \n" +
                     "       AND (TIMESTAMPDIFF(WEEK, pe.birthdate, CURDATE()) BETWEEN 10 AND 24) AND et.uuid='9fcfcc91-ad60-4d84-9710-11cc25258719'   AND p.patient_id \n" +
                     " NOT IN (SELECT ee.patient_id FROM encounter ee INNER JOIN encounter_type ete ON ee.encounter_type = ete.encounter_type_id WHERE ete.uuid = '8d5b27bc-c2cc-11de-8d13-0010c6dffd0f' AND ee.voided = FALSE)  GROUP BY p.patient_id  HAVING p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 99606 AND oo.voided = FALSE)\n" +
                     " AND p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 90306 AND oo.voided = FALSE)";
@@ -448,7 +448,7 @@ public class Flags {
             return "SELECT p.patient_id , DATE_FORMAT(DATE_ADD(pe.birthdate, INTERVAL 13 MONTH), '%d.%b.%Y') FROM patient p  \n" +
                     " INNER JOIN obs o ON p.patient_id = o.person_id   INNER JOIN person pe ON p.patient_id = pe.person_id  \n" +
                     "  INNER JOIN encounter e ON o.encounter_id = e.encounter_id   INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id \n" +
-                    "  WHERE pe.dead=FALSE AND pe.voided=FALSE \n" +
+                    "  WHERE pe.dead=FALSE  \n" +
                     "    AND (TIMESTAMPDIFF(MONTH, pe.birthdate, CURDATE()) BETWEEN 13 AND 14) AND et.uuid='9fcfcc91-ad60-4d84-9710-11cc25258719'        \n" +
                     "     AND p.patient_id NOT IN (SELECT ee.patient_id FROM encounter ee INNER JOIN encounter_type ete ON ee.encounter_type = ete.encounter_type_id \n" +
                     "     WHERE ete.uuid = '8d5b27bc-c2cc-11de-8d13-0010c6dffd0f' AND ee.voided = FALSE)  GROUP BY p.patient_id  \n" +
@@ -493,7 +493,7 @@ public class Flags {
             return "SELECT p.patient_id , DATE_FORMAT(DATE_ADD(pe.birthdate, INTERVAL 13 MONTH), '%d.%b.%Y') FROM patient p  \n" +
                     " INNER JOIN obs o ON p.patient_id = o.person_id   INNER JOIN person pe ON p.patient_id = pe.person_id  \n" +
                     "  INNER JOIN encounter e ON o.encounter_id = e.encounter_id   INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id \n" +
-                    "  WHERE pe.dead=FALSE AND pe.voided=FALSE  \n" +
+                    "  WHERE pe.dead=FALSE   \n" +
                     "   AND  (TIMESTAMPDIFF(MONTH, pe.birthdate, CURDATE()) BETWEEN 15 AND 17) AND et.uuid='9fcfcc91-ad60-4d84-9710-11cc25258719'     \n" +
                     "       AND p.patient_id NOT IN (SELECT ee.patient_id FROM encounter ee INNER JOIN encounter_type ete ON ee.encounter_type = ete.encounter_type_id \n" +
                     "       WHERE ete.uuid = '8d5b27bc-c2cc-11de-8d13-0010c6dffd0f' AND ee.voided = FALSE)  GROUP BY p.patient_id  \n" +
@@ -538,7 +538,7 @@ public class Flags {
             return "SELECT p.patient_id , DATE_FORMAT(DATE_ADD(pe.birthdate, INTERVAL 18 MONTH), '%d.%b.%Y') FROM patient p \n" +
                     "  INNER JOIN obs o ON p.patient_id = o.person_id   INNER JOIN person pe ON p.patient_id = pe.person_id   \n" +
                     "  INNER JOIN encounter e ON o.encounter_id = e.encounter_id   INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id \n" +
-                    "  WHERE pe.dead=FALSE AND pe.voided=FALSE   \n" +
+                    "  WHERE pe.dead=FALSE    \n" +
                     "  AND TIMESTAMPDIFF(MONTH, pe.birthdate, CURDATE()) = 18 AND et.uuid='9fcfcc91-ad60-4d84-9710-11cc25258719'         \n" +
                     "  AND p.patient_id NOT IN (SELECT ee.patient_id FROM encounter ee INNER JOIN encounter_type ete ON ee.encounter_type = ete.encounter_type_id \n" +
                     "  WHERE ete.uuid = '8d5b27bc-c2cc-11de-8d13-0010c6dffd0f' AND ee.voided = FALSE)  GROUP BY p.patient_id  \n" +
@@ -583,7 +583,7 @@ public class Flags {
             return "SELECT p.patient_id , DATE_FORMAT(DATE_ADD(pe.birthdate, INTERVAL 18 MONTH), '%d.%b.%Y') FROM patient p \n" +
             "  INNER JOIN obs o ON p.patient_id = o.person_id   INNER JOIN person pe ON p.patient_id = pe.person_id \n" +
                     "    INNER JOIN encounter e ON o.encounter_id = e.encounter_id   INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id \n" +
-                    "    WHERE pe.dead=FALSE AND pe.voided=FALSE  \n" +
+                    "    WHERE pe.dead=FALSE   \n" +
                     "      AND (TIMESTAMPDIFF(MONTH, pe.birthdate, CURDATE()) BETWEEN 19 AND 24) AND et.uuid='9fcfcc91-ad60-4d84-9710-11cc25258719'      \n" +
                     "         AND p.patient_id NOT IN (SELECT ee.patient_id FROM encounter ee \n" +
                     "         INNER JOIN encounter_type ete ON ee.encounter_type = ete.encounter_type_id \n" +
@@ -632,7 +632,7 @@ public class Flags {
                     "      INNER JOIN (SELECT c.person_id as patient_id, obs_datetime, value_numeric\n" +
                     "                  FROM obs c WHERE c.concept_id = 856 AND c.voided = 0 AND c.value_numeric > 1) non_suppressed\n" +
                     "      ON (latest_vl.person_id = non_suppressed.patient_id and latest_vl.dt = non_suppressed.obs_datetime)\n" +
-                    "      INNER JOIN person pe ON pe.person_id = non_suppressed.patient_id WHERE pe.dead=FALSE AND pe.voided=FALSE\n" +
+                    "      INNER JOIN person pe ON pe.person_id = non_suppressed.patient_id WHERE pe.dead=FALSE\n" +
                     "      AND non_suppressed.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 90306 AND oo.voided = FALSE)";
         }
 

--- a/api/src/main/java/org/openmrs/module/aijar/metadata/core/Flags.java
+++ b/api/src/main/java/org/openmrs/module/aijar/metadata/core/Flags.java
@@ -10,11 +10,13 @@ public class Flags {
     public static FlagDescriptor DUE_FOR_FIRST_VIRAL_LOAD = new FlagDescriptor() {
         @Override
         public String criteria() {
-            return "SELECT p.patient_id, DATE_FORMAT(DATE_ADD(o.value_datetime, INTERVAL 6 MONTH), '%d.%b.%Y') FROM patient p " +
-                    " INNER JOIN obs o ON p.patient_id = o.person_id " +
-                    " INNER JOIN encounter e ON o.encounter_id = e.encounter_id " +
-                    " INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id " +
-                    " WHERE ((o.concept_id = 99161 AND o.voided = FALSE AND e.voided = FALSE AND ((CURRENT_DATE() BETWEEN DATE_ADD(o.value_datetime, INTERVAL 5 MONTH) AND DATE_ADD(o.value_datetime, INTERVAL 6 MONTH)) AND et.uuid='8d5b27bc-c2cc-11de-8d13-0010c6dffd0f'))) AND o.person_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 1305 AND oo.voided = FALSE)";
+            return "SELECT p.patient_id, DATE_FORMAT(DATE_ADD(o.value_datetime, INTERVAL 6 MONTH), '%d.%b.%Y') FROM patient p \n" +
+                    " INNER JOIN obs o ON p.patient_id = o.person_id  INNER JOIN encounter e ON o.encounter_id = e.encounter_id  \n" +
+                    " INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id \n" +
+                    " INNER JOIN person pp ON pp.person_id=p.patient_id  WHERE  pp.dead =false and pp.voided=false\n" +
+                    "  AND ((o.concept_id = 99161 AND o.voided = FALSE AND e.voided = FALSE AND ((CURRENT_DATE() BETWEEN DATE_ADD(o.value_datetime, INTERVAL 5 MONTH) AND DATE_ADD(o.value_datetime, INTERVAL 6 MONTH)) AND et.uuid='8d5b27bc-c2cc-11de-8d13-0010c6dffd0f'))) AND o.person_id \n" +
+                    "  NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 1305 AND oo.voided = FALSE)\n" +
+                    " AND p.patient_id NOT IN (select o.person_id from obs o where concept_id=90306 and o.voided=FALSE)";
         }
 
         @Override
@@ -51,10 +53,12 @@ public class Flags {
     public static FlagDescriptor OVERDUE_FOR_FIRST_VIRAL_LOAD = new FlagDescriptor() {
         @Override
         public String criteria() {
-            return "SELECT p.patient_id, DATE_FORMAT(DATE_ADD(o.value_datetime, INTERVAL 6 MONTH), '%d.%b.%Y') FROM patient p " +
-                    " INNER JOIN obs o ON p.patient_id = o.person_id " +
-                    " WHERE o.concept_id = 99161 AND o.voided = FALSE AND CURRENT_DATE() >= DATE_ADD(o.value_datetime, INTERVAL 6 MONTH) " +
-                    " AND o.person_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 1305 AND oo.voided = FALSE)";
+            return "SELECT p.patient_id, DATE_FORMAT(DATE_ADD(o.value_datetime, INTERVAL 6 MONTH), '%d.%b.%Y') FROM patient p\n" +
+                    "                     INNER JOIN obs o ON p.patient_id = o.person_id\n" +
+                    "                     INNER JOIN person pp ON pp.person_id = p.patient_id WHERE pp.dead = FALSE AND pp.voided = false \n" +
+                    "                     AND  o.concept_id = 99161 AND o.voided = FALSE AND CURRENT_DATE() >= DATE_ADD(o.value_datetime, INTERVAL 6 MONTH)\n" +
+                    "                     AND o.person_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 1305 AND oo.voided = FALSE)\n" +
+                    "                     AND p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 90306 AND oo.voided = FALSE)";
         }
 
         @Override
@@ -91,12 +95,14 @@ public class Flags {
     public static FlagDescriptor DUE_FOR_ROUTINE_VIRAL_LOAD = new FlagDescriptor() {
         @Override
         public String criteria() {
-            return "SELECT p.patient_id, DATE_FORMAT(IF(TIMESTAMPDIFF(YEAR, pe.birthdate, CURDATE()) < 16, DATE_ADD(MAX(o.value_datetime), INTERVAL 6 MONTH), DATE_ADD(MAX(o.value_datetime), INTERVAL 12 MONTH)), '%d.%b.%Y') FROM patient p " +
-                    "  INNER JOIN obs o ON p.patient_id = o.person_id " +
-                    "  INNER JOIN person pe ON o.person_id = pe.person_id " +
-                    " WHERE o.concept_id = 163023 AND o.voided = FALSE " +
-                    " GROUP BY pe.person_id, pe.birthdate " +
-                    " HAVING DATEDIFF(IF(TIMESTAMPDIFF(YEAR, pe.birthdate, CURDATE()) < 16, DATE_ADD(MAX(o.value_datetime), INTERVAL 6 MONTH), DATE_ADD(MAX(o.value_datetime), INTERVAL 12 MONTH)), CURRENT_DATE()) BETWEEN 0 AND 30";
+            return "SELECT p.patient_id, DATE_FORMAT(IF(TIMESTAMPDIFF(YEAR, pe.birthdate, CURDATE()) < 16, DATE_ADD(MAX(o.value_datetime), INTERVAL 6 MONTH), DATE_ADD(MAX(o.value_datetime), INTERVAL 12 MONTH)), '%d.%b.%Y') FROM patient p\n" +
+                    "INNER JOIN obs o ON p.patient_id = o.person_id \n" +
+                    "INNER JOIN person pe ON o.person_id = pe.person_id \n" +
+                    "WHERE pe.dead=FALSE AND pe.voided=FALSE\n" +
+                    "AND o.concept_id = 163023 AND o.voided = FALSE \n" +
+                    "GROUP BY pe.person_id, pe.birthdate \n" +
+                    "HAVING DATEDIFF(IF(TIMESTAMPDIFF(YEAR, pe.birthdate, CURDATE()) < 16, DATE_ADD(MAX(o.value_datetime), INTERVAL 6 MONTH), DATE_ADD(MAX(o.value_datetime), INTERVAL 12 MONTH)), CURRENT_DATE()) BETWEEN 0 AND 30\n" +
+                    "AND p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 90306 AND oo.voided = FALSE)";
         }
 
         @Override
@@ -133,12 +139,14 @@ public class Flags {
     public static FlagDescriptor OVERDUE_FOR_ROUTINE_VIRAL_LOAD = new FlagDescriptor() {
         @Override
         public String criteria() {
-            return "SELECT p.patient_id, DATE_FORMAT(IF(TIMESTAMPDIFF(YEAR, pe.birthdate, CURDATE()) < 16, DATE_ADD(MAX(o.value_datetime), INTERVAL 6 MONTH), DATE_ADD(MAX(o.value_datetime), INTERVAL 12 MONTH)), '%d.%b.%Y') FROM patient p " +
-                    "  INNER JOIN obs o ON p.patient_id = o.person_id " +
-                    "  INNER JOIN person pe ON o.person_id = pe.person_id " +
-                    " WHERE o.concept_id = 163023 AND o.voided = FALSE " +
-                    " GROUP BY pe.person_id, pe.birthdate " +
-                    " HAVING CURRENT_DATE() > IF(TIMESTAMPDIFF(YEAR, pe.birthdate, CURDATE()) < 16, DATE_ADD(MAX(o.value_datetime), INTERVAL 6 MONTH), DATE_ADD(MAX(o.value_datetime), INTERVAL 12 MONTH))";
+            return "SELECT p.patient_id, DATE_FORMAT(IF(TIMESTAMPDIFF(YEAR, pe.birthdate, CURDATE()) < 16, DATE_ADD(MAX(o.value_datetime), INTERVAL 6 MONTH), DATE_ADD(MAX(o.value_datetime), INTERVAL 12 MONTH)), '%d.%b.%Y') FROM patient p \n" +
+                    "INNER JOIN obs o ON p.patient_id = o.person_id\n" +
+                    "INNER JOIN person pe ON o.person_id = pe.person_id \n" +
+                    " WHERE pe.dead=FALSE AND pe.voided=FALSE\n" +
+                    "AND  o.concept_id = 163023 AND o.voided = FALSE\n" +
+                    "GROUP BY pe.person_id, pe.birthdate \n" +
+                    "HAVING CURRENT_DATE() > IF(TIMESTAMPDIFF(YEAR, pe.birthdate, CURDATE()) < 16, DATE_ADD(MAX(o.value_datetime), INTERVAL 6 MONTH), DATE_ADD(MAX(o.value_datetime), INTERVAL 12 MONTH))\n" +
+                    "AND p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 90306 AND oo.voided = FALSE)";
         }
 
         @Override
@@ -175,7 +183,12 @@ public class Flags {
     public static FlagDescriptor UPCOMING_APPOINTMENT = new FlagDescriptor() {
         @Override
         public String criteria() {
-            return "SELECT p.patient_id, DATE_FORMAT(MAX(o.value_datetime), '%d.%b.%Y') FROM patient p INNER JOIN obs o ON p.patient_id = o.person_id WHERE o.concept_id = 5096 AND o.voided = FALSE  GROUP BY o.person_id HAVING MAX(o.value_datetime) >= CURRENT_DATE()";
+            return "SELECT p.patient_id, DATE_FORMAT(MAX(o.value_datetime), '%d.%b.%Y') FROM patient p \n" +
+                    "INNER JOIN obs o ON p.patient_id = o.person_id \n" +
+                    "INNER JOIN person pe on pe.person_id=p.patient_id\n" +
+                    " WHERE pe.dead=FALSE AND pe.voided=FALSE\n" +
+                    "AND  o.concept_id = 5096 AND o.voided = FALSE  GROUP BY o.person_id HAVING MAX(o.value_datetime) >= CURRENT_DATE()\n" +
+                    "AND p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 90306 AND oo.voided = FALSE)";
         }
 
         @Override
@@ -212,7 +225,14 @@ public class Flags {
     public static FlagDescriptor MISSED_APPOINTMENT = new FlagDescriptor() {
         @Override
         public String criteria() {
-            return "SELECT p.patient_id, DATE_FORMAT(MAX(o.value_datetime), '%d.%b.%Y') FROM patient p INNER JOIN obs o ON p.patient_id = o.person_id WHERE o.concept_id = 5096 AND o.voided = FALSE GROUP BY o.person_id HAVING MAX(o.value_datetime) BETWEEN DATE_SUB(CURRENT_DATE(), INTERVAL 29 DAY) AND DATE_SUB(CURRENT_DATE(), INTERVAL 7 DAY)";
+            return "SELECT p.patient_id, DATE_FORMAT(MAX(o.value_datetime), '%d.%b.%Y') \n" +
+                    "FROM patient p\n" +
+                    " INNER JOIN obs o ON p.patient_id = o.person_id \n" +
+                    " INNER JOIN person pe on pe.person_id=p.patient_id\n" +
+                    " WHERE pe.dead=FALSE AND pe.voided=FALSE\n" +
+                    " AND o.concept_id = 5096 AND o.voided = FALSE GROUP BY o.person_id \n" +
+                    " HAVING MAX(o.value_datetime) BETWEEN DATE_SUB(CURRENT_DATE(), INTERVAL 29 DAY) AND DATE_SUB(CURRENT_DATE(), INTERVAL 7 DAY)\n" +
+                    " AND p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 90306 AND oo.voided = FALSE)";
         }
 
         @Override
@@ -249,7 +269,13 @@ public class Flags {
     public static FlagDescriptor PATIENT_LOST = new FlagDescriptor() {
         @Override
         public String criteria() {
-            return "SELECT p.patient_id, DATE_FORMAT(DATE_ADD(MAX(o.value_datetime), INTERVAL 30 DAY), '%d.%b.%Y') FROM patient p INNER JOIN obs o ON p.patient_id = o.person_id WHERE o.concept_id = 5096 AND o.voided = FALSE GROUP BY o.person_id HAVING MAX(o.value_datetime) BETWEEN DATE_SUB(CURRENT_DATE(), INTERVAL 89 DAY) AND DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY)";
+            return "SELECT p.patient_id, DATE_FORMAT(DATE_ADD(MAX(o.value_datetime), INTERVAL 30 DAY), '%d.%b.%Y') FROM patient p\n" +
+                    "   INNER JOIN obs o ON p.patient_id = o.person_id\n" +
+                    "   INNER JOIN person pe on pe.person_id=p.patient_id\n" +
+                    "   WHERE pe.dead=FALSE AND pe.voided=FALSE\n" +
+                    "    AND o.concept_id = 5096 AND o.voided = FALSE GROUP BY o.person_id \n" +
+                    "   HAVING MAX(o.value_datetime) BETWEEN DATE_SUB(CURRENT_DATE(), INTERVAL 89 DAY) AND DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY)\n" +
+                    "   AND p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 90306 AND oo.voided = FALSE)";
         }
 
         @Override
@@ -287,11 +313,11 @@ public class Flags {
         @Override
         public String criteria() {
             return "SELECT p.patient_id, DATE_FORMAT(DATE_ADD(MAX(o.value_datetime), INTERVAL 90 DAY), '%d.%b.%Y') FROM patient p\n" +
-                    "                    INNER JOIN obs o ON p.patient_id = o.person_id \n" +
-                    "                    INNER JOIN person pp ON pp.person_id=p.patient_id \n" +
-                    "                    WHERE  pp.dead =false and pp.voided=false AND o.concept_id = 5096 AND  o.voided = FALSE GROUP BY o.person_id \n" +
-                    "                    HAVING MAX(o.value_datetime) <= DATE_SUB(CURRENT_DATE(), INTERVAL 90 DAY)\n" +
-                    "                    AND p.patient_id NOT IN (select o.person_id from obs o where concept_id=90306 and o.voided=false)";
+                    " INNER JOIN obs o ON p.patient_id = o.person_id \n" +
+                    "INNER JOIN person pp ON pp.person_id=p.patient_id \n" +
+                    "WHERE  pp.dead =false and pp.voided=false AND o.concept_id = 5096 AND  o.voided = FALSE GROUP BY o.person_id \n" +
+                    "HAVING MAX(o.value_datetime) <= DATE_SUB(CURRENT_DATE(), INTERVAL 90 DAY)\n" +
+                    "AND p.patient_id NOT IN (select o.person_id from obs o where concept_id=90306 and o.voided=false)";
         }
 
         @Override
@@ -328,15 +354,16 @@ public class Flags {
     public static FlagDescriptor DUE_FOR_FIRST_DNA_PCR = new FlagDescriptor() {
         @Override
         public String criteria() {
-            return "SELECT p.patient_id , DATE_FORMAT(DATE_ADD(pe.birthdate, INTERVAL 6 WEEK), '%d.%b.%Y') FROM patient p " +
-                    "  INNER JOIN obs o ON p.patient_id = o.person_id " +
-                    "  INNER JOIN person pe ON p.patient_id = pe.person_id " +
-                    "  INNER JOIN encounter e ON o.encounter_id = e.encounter_id " +
-                    "  INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id " +
-                    "  WHERE (TIMESTAMPDIFF(WEEK, pe.birthdate, CURDATE()) BETWEEN 6 AND 9) AND et.uuid='9fcfcc91-ad60-4d84-9710-11cc25258719' " +
-                    "        AND p.patient_id NOT IN (SELECT ee.patient_id FROM encounter ee INNER JOIN encounter_type ete ON ee.encounter_type = ete.encounter_type_id WHERE ete.uuid = '8d5b27bc-c2cc-11de-8d13-0010c6dffd0f' AND ee.voided = FALSE) " +
-                    " GROUP BY p.patient_id " +
-                    " HAVING p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 99606 AND oo.voided = FALSE) ";
+            return "SELECT p.patient_id , DATE_FORMAT(DATE_ADD(pe.birthdate, INTERVAL 6 WEEK), '%d.%b.%Y') FROM patient p  \n" +
+                    " INNER JOIN obs o ON p.patient_id = o.person_id   \n" +
+                    " INNER JOIN person pe ON p.patient_id = pe.person_id \n" +
+                    " INNER JOIN encounter e ON o.encounter_id = e.encounter_id \n" +
+                    " INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id \n" +
+                    " WHERE pe.dead=FALSE AND pe.voided=FALSE  \n" +
+                    " AND (TIMESTAMPDIFF(WEEK, pe.birthdate, CURDATE()) BETWEEN 6 AND 9) AND et.uuid='9fcfcc91-ad60-4d84-9710-11cc25258719'\n" +
+                    " AND p.patient_id NOT IN (SELECT ee.patient_id FROM encounter ee INNER JOIN encounter_type ete ON ee.encounter_type = ete.encounter_type_id WHERE ete.uuid = '8d5b27bc-c2cc-11de-8d13-0010c6dffd0f' AND ee.voided = FALSE)  GROUP BY p.patient_id \n" +
+                    " HAVING p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 99606 AND oo.voided = FALSE)\n" +
+                    "AND p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 90306 AND oo.voided = FALSE) ";
         }
 
         @Override
@@ -373,15 +400,15 @@ public class Flags {
     public static FlagDescriptor OVERDUE_FOR_FIRST_DNA_PCR = new FlagDescriptor() {
         @Override
         public String criteria() {
-            return "SELECT p.patient_id , DATE_FORMAT(DATE_ADD(pe.birthdate, INTERVAL 6 WEEK), '%d.%b.%Y') FROM patient p " +
-                    "  INNER JOIN obs o ON p.patient_id = o.person_id " +
-                    "  INNER JOIN person pe ON p.patient_id = pe.person_id " +
-                    "  INNER JOIN encounter e ON o.encounter_id = e.encounter_id " +
-                    "  INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id " +
-                    "  WHERE (TIMESTAMPDIFF(WEEK, pe.birthdate, CURDATE()) BETWEEN 10 AND 24) AND et.uuid='9fcfcc91-ad60-4d84-9710-11cc25258719' " +
-                    "        AND p.patient_id NOT IN (SELECT ee.patient_id FROM encounter ee INNER JOIN encounter_type ete ON ee.encounter_type = ete.encounter_type_id WHERE ete.uuid = '8d5b27bc-c2cc-11de-8d13-0010c6dffd0f' AND ee.voided = FALSE) " +
-                    " GROUP BY p.patient_id " +
-                    " HAVING p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 99606 AND oo.voided = FALSE) ";
+            return "SELECT p.patient_id , DATE_FORMAT(DATE_ADD(pe.birthdate, INTERVAL 6 WEEK), '%d.%b.%Y') FROM patient p \n" +
+                    "  INNER JOIN obs o ON p.patient_id = o.person_id   \n" +
+                    "  INNER JOIN person pe ON p.patient_id = pe.person_id \n" +
+                    "    INNER JOIN encounter e ON o.encounter_id = e.encounter_id  \n" +
+                    "     INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id \n" +
+                    "WHERE pe.dead=FALSE AND pe.voided=FALSE \n" +
+                    "       AND (TIMESTAMPDIFF(WEEK, pe.birthdate, CURDATE()) BETWEEN 10 AND 24) AND et.uuid='9fcfcc91-ad60-4d84-9710-11cc25258719'   AND p.patient_id \n" +
+                    " NOT IN (SELECT ee.patient_id FROM encounter ee INNER JOIN encounter_type ete ON ee.encounter_type = ete.encounter_type_id WHERE ete.uuid = '8d5b27bc-c2cc-11de-8d13-0010c6dffd0f' AND ee.voided = FALSE)  GROUP BY p.patient_id  HAVING p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 99606 AND oo.voided = FALSE)\n" +
+                    " AND p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 90306 AND oo.voided = FALSE)";
         }
 
         @Override
@@ -418,15 +445,15 @@ public class Flags {
     public static FlagDescriptor DUE_FOR_SECOND_DNA_PCR = new FlagDescriptor() {
         @Override
         public String criteria() {
-            return "SELECT p.patient_id , DATE_FORMAT(DATE_ADD(pe.birthdate, INTERVAL 13 MONTH), '%d.%b.%Y') FROM patient p " +
-                    "  INNER JOIN obs o ON p.patient_id = o.person_id " +
-                    "  INNER JOIN person pe ON p.patient_id = pe.person_id " +
-                    "  INNER JOIN encounter e ON o.encounter_id = e.encounter_id " +
-                    "  INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id " +
-                    "  WHERE (TIMESTAMPDIFF(MONTH, pe.birthdate, CURDATE()) BETWEEN 13 AND 14) AND et.uuid='9fcfcc91-ad60-4d84-9710-11cc25258719' " +
-                    "        AND p.patient_id NOT IN (SELECT ee.patient_id FROM encounter ee INNER JOIN encounter_type ete ON ee.encounter_type = ete.encounter_type_id WHERE ete.uuid = '8d5b27bc-c2cc-11de-8d13-0010c6dffd0f' AND ee.voided = FALSE) " +
-                    " GROUP BY p.patient_id " +
-                    " HAVING p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 99436 AND oo.voided = FALSE)";
+            return "SELECT p.patient_id , DATE_FORMAT(DATE_ADD(pe.birthdate, INTERVAL 13 MONTH), '%d.%b.%Y') FROM patient p  \n" +
+                    " INNER JOIN obs o ON p.patient_id = o.person_id   INNER JOIN person pe ON p.patient_id = pe.person_id  \n" +
+                    "  INNER JOIN encounter e ON o.encounter_id = e.encounter_id   INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id \n" +
+                    "  WHERE pe.dead=FALSE AND pe.voided=FALSE \n" +
+                    "    AND (TIMESTAMPDIFF(MONTH, pe.birthdate, CURDATE()) BETWEEN 13 AND 14) AND et.uuid='9fcfcc91-ad60-4d84-9710-11cc25258719'        \n" +
+                    "     AND p.patient_id NOT IN (SELECT ee.patient_id FROM encounter ee INNER JOIN encounter_type ete ON ee.encounter_type = ete.encounter_type_id \n" +
+                    "     WHERE ete.uuid = '8d5b27bc-c2cc-11de-8d13-0010c6dffd0f' AND ee.voided = FALSE)  GROUP BY p.patient_id  \n" +
+                    "     HAVING p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 99436 AND oo.voided = FALSE)\n" +
+                    "   AND p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 90306 AND oo.voided = FALSE)";
         }
 
         @Override
@@ -463,15 +490,15 @@ public class Flags {
     public static FlagDescriptor OVERDUE_FOR_SECOND_DNA_PCR = new FlagDescriptor() {
         @Override
         public String criteria() {
-            return "SELECT p.patient_id , DATE_FORMAT(DATE_ADD(pe.birthdate, INTERVAL 13 MONTH), '%d.%b.%Y') FROM patient p " +
-                    "  INNER JOIN obs o ON p.patient_id = o.person_id " +
-                    "  INNER JOIN person pe ON p.patient_id = pe.person_id " +
-                    "  INNER JOIN encounter e ON o.encounter_id = e.encounter_id " +
-                    "  INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id " +
-                    "  WHERE (TIMESTAMPDIFF(MONTH, pe.birthdate, CURDATE()) BETWEEN 15 AND 17) AND et.uuid='9fcfcc91-ad60-4d84-9710-11cc25258719' " +
-                    "        AND p.patient_id NOT IN (SELECT ee.patient_id FROM encounter ee INNER JOIN encounter_type ete ON ee.encounter_type = ete.encounter_type_id WHERE ete.uuid = '8d5b27bc-c2cc-11de-8d13-0010c6dffd0f' AND ee.voided = FALSE) " +
-                    " GROUP BY p.patient_id " +
-                    " HAVING p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 99436 AND oo.voided = FALSE)";
+            return "SELECT p.patient_id , DATE_FORMAT(DATE_ADD(pe.birthdate, INTERVAL 13 MONTH), '%d.%b.%Y') FROM patient p  \n" +
+                    " INNER JOIN obs o ON p.patient_id = o.person_id   INNER JOIN person pe ON p.patient_id = pe.person_id  \n" +
+                    "  INNER JOIN encounter e ON o.encounter_id = e.encounter_id   INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id \n" +
+                    "  WHERE pe.dead=FALSE AND pe.voided=FALSE  \n" +
+                    "   AND  (TIMESTAMPDIFF(MONTH, pe.birthdate, CURDATE()) BETWEEN 15 AND 17) AND et.uuid='9fcfcc91-ad60-4d84-9710-11cc25258719'     \n" +
+                    "       AND p.patient_id NOT IN (SELECT ee.patient_id FROM encounter ee INNER JOIN encounter_type ete ON ee.encounter_type = ete.encounter_type_id \n" +
+                    "       WHERE ete.uuid = '8d5b27bc-c2cc-11de-8d13-0010c6dffd0f' AND ee.voided = FALSE)  GROUP BY p.patient_id  \n" +
+                    "    HAVING p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 99436 AND oo.voided = FALSE)\n" +
+                    "    AND p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 90306 AND oo.voided = FALSE)";
         }
 
         @Override
@@ -508,15 +535,15 @@ public class Flags {
     public static FlagDescriptor DUE_FOR_RAPID_TEST = new FlagDescriptor() {
         @Override
         public String criteria() {
-            return "SELECT p.patient_id , DATE_FORMAT(DATE_ADD(pe.birthdate, INTERVAL 18 MONTH), '%d.%b.%Y') FROM patient p " +
-                    "  INNER JOIN obs o ON p.patient_id = o.person_id " +
-                    "  INNER JOIN person pe ON p.patient_id = pe.person_id " +
-                    "  INNER JOIN encounter e ON o.encounter_id = e.encounter_id " +
-                    "  INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id " +
-                    "  WHERE TIMESTAMPDIFF(MONTH, pe.birthdate, CURDATE()) = 18 AND et.uuid='9fcfcc91-ad60-4d84-9710-11cc25258719' " +
-                    "        AND p.patient_id NOT IN (SELECT ee.patient_id FROM encounter ee INNER JOIN encounter_type ete ON ee.encounter_type = ete.encounter_type_id WHERE ete.uuid = '8d5b27bc-c2cc-11de-8d13-0010c6dffd0f' AND ee.voided = FALSE) " +
-                    " GROUP BY p.patient_id " +
-                    " HAVING p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 162879 AND oo.voided = FALSE)";
+            return "SELECT p.patient_id , DATE_FORMAT(DATE_ADD(pe.birthdate, INTERVAL 18 MONTH), '%d.%b.%Y') FROM patient p \n" +
+                    "  INNER JOIN obs o ON p.patient_id = o.person_id   INNER JOIN person pe ON p.patient_id = pe.person_id   \n" +
+                    "  INNER JOIN encounter e ON o.encounter_id = e.encounter_id   INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id \n" +
+                    "  WHERE pe.dead=FALSE AND pe.voided=FALSE   \n" +
+                    "  AND TIMESTAMPDIFF(MONTH, pe.birthdate, CURDATE()) = 18 AND et.uuid='9fcfcc91-ad60-4d84-9710-11cc25258719'         \n" +
+                    "  AND p.patient_id NOT IN (SELECT ee.patient_id FROM encounter ee INNER JOIN encounter_type ete ON ee.encounter_type = ete.encounter_type_id \n" +
+                    "  WHERE ete.uuid = '8d5b27bc-c2cc-11de-8d13-0010c6dffd0f' AND ee.voided = FALSE)  GROUP BY p.patient_id  \n" +
+                    "  HAVING p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 162879 AND oo.voided = FALSE)\n" +
+                    "   AND p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 90306 AND oo.voided = FALSE)";
         }
 
         @Override
@@ -553,15 +580,16 @@ public class Flags {
     public static FlagDescriptor OVERDUE_FOR_RAPID_TEST = new FlagDescriptor() {
         @Override
         public String criteria() {
-            return "SELECT p.patient_id , DATE_FORMAT(DATE_ADD(pe.birthdate, INTERVAL 18 MONTH), '%d.%b.%Y') FROM patient p " +
-                    "  INNER JOIN obs o ON p.patient_id = o.person_id " +
-                    "  INNER JOIN person pe ON p.patient_id = pe.person_id " +
-                    "  INNER JOIN encounter e ON o.encounter_id = e.encounter_id " +
-                    "  INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id " +
-                    "  WHERE (TIMESTAMPDIFF(MONTH, pe.birthdate, CURDATE()) BETWEEN 19 AND 24) AND et.uuid='9fcfcc91-ad60-4d84-9710-11cc25258719' " +
-                    "        AND p.patient_id NOT IN (SELECT ee.patient_id FROM encounter ee INNER JOIN encounter_type ete ON ee.encounter_type = ete.encounter_type_id WHERE ete.uuid = '8d5b27bc-c2cc-11de-8d13-0010c6dffd0f' AND ee.voided = FALSE) " +
-                    " GROUP BY p.patient_id " +
-                    " HAVING p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 162879 AND oo.voided = FALSE)";
+            return "SELECT p.patient_id , DATE_FORMAT(DATE_ADD(pe.birthdate, INTERVAL 18 MONTH), '%d.%b.%Y') FROM patient p \n" +
+            "  INNER JOIN obs o ON p.patient_id = o.person_id   INNER JOIN person pe ON p.patient_id = pe.person_id \n" +
+                    "    INNER JOIN encounter e ON o.encounter_id = e.encounter_id   INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id \n" +
+                    "    WHERE pe.dead=FALSE AND pe.voided=FALSE  \n" +
+                    "      AND (TIMESTAMPDIFF(MONTH, pe.birthdate, CURDATE()) BETWEEN 19 AND 24) AND et.uuid='9fcfcc91-ad60-4d84-9710-11cc25258719'      \n" +
+                    "         AND p.patient_id NOT IN (SELECT ee.patient_id FROM encounter ee \n" +
+                    "         INNER JOIN encounter_type ete ON ee.encounter_type = ete.encounter_type_id \n" +
+                    "         WHERE ete.uuid = '8d5b27bc-c2cc-11de-8d13-0010c6dffd0f' AND ee.voided = FALSE)  GROUP BY p.patient_id \n" +
+                    "          HAVING p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 162879 AND oo.voided = FALSE)\n" +
+                    "       AND p.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 90306 AND oo.voided = FALSE) ";
         }
 
         @Override
@@ -598,12 +626,14 @@ public class Flags {
     public static FlagDescriptor HAS_DETECTABLE_VIRAL_LOAD = new FlagDescriptor() {
         @Override
         public String criteria() {
-            return " SELECT non_suppressed.patient_id, non_suppressed.value_numeric, DATE_FORMAT((non_suppressed.obs_datetime), '%d. %b. %Y')\n" +
+            return "SELECT non_suppressed.patient_id, non_suppressed.value_numeric, DATE_FORMAT((non_suppressed.obs_datetime), '%d. %b. %Y')\n" +
                     " FROM (SELECT person_id, MAX(obs_datetime) as dt FROM obs b\n" +
                     "        WHERE b.concept_id = 856 AND b.voided = 0 group by person_id) latest_vl\n" +
                     "      INNER JOIN (SELECT c.person_id as patient_id, obs_datetime, value_numeric\n" +
                     "                  FROM obs c WHERE c.concept_id = 856 AND c.voided = 0 AND c.value_numeric > 1) non_suppressed\n" +
-                    "      ON (latest_vl.person_id = non_suppressed.patient_id and latest_vl.dt = non_suppressed.obs_datetime) ";
+                    "      ON (latest_vl.person_id = non_suppressed.patient_id and latest_vl.dt = non_suppressed.obs_datetime)\n" +
+                    "      INNER JOIN person pe ON pe.person_id = non_suppressed.patient_id WHERE pe.dead=FALSE AND pe.voided=FALSE\n" +
+                    "      AND non_suppressed.patient_id NOT IN (SELECT oo.person_id FROM obs oo WHERE oo.concept_id = 90306 AND oo.voided = FALSE)";
         }
 
         @Override


### PR DESCRIPTION
https://trello.com/c/PRm5cuIY/781-patient-flags-do-not-run-for-patients-who-are-dead-and-transferred-out.
Exluded all patients flags from a patient once they are marked dead or transferred