### PR TITLE
Add an onError condition to handle cases where the global property does not exist so throws an error due to the null value

### DIFF
--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -9,7 +9,7 @@
         for a list of supported elements and attributes
     -->
 	<changeSet id="ugandaemr-27112020-1441" author="ssmusoke">
-		<preConditions onFail="MARK_RAN">
+		<preConditions onFail="MARK_RAN" onError="MARK_RAN">
 			<sqlCheck expectedResult="100">
 				SELECT property_value
 				FROM global_property
@@ -19,6 +19,7 @@
 		<comment>Reset maximum patients per day value to blank which is unlimited</comment>
 		<sql>UPDATE global_property SET property_value = '' WHERE property = 'ugandaemr.maximumPatientsPerDay'</sql>
 	</changeSet>
+
 	<changeSet id="ugandaemr-05092018-1043" author="ssmusoke">
 		<comment>Fix bad data for the ART care section which is causing an error when saving the summary page</comment>
 		<sql>

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -180,7 +180,7 @@
     <globalProperty>
 		<property>ugandaemr.maximumPatientsPerDay</property>
         <description>The maxiumum number of patients that can have appointments on a single day</description>
-		<defaultValue>100</defaultValue>
+		<defaultValue></defaultValue>
 	</globalProperty>
 
     <globalProperty>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
 		<appointmentschedulingVersion>1.12.0</appointmentschedulingVersion>
 		<appointmentschedulinguiVersion>1.9.0</appointmentschedulinguiVersion>
 		<calculationVersion>1.2</calculationVersion>
-		<coreappsVersion>1.30.0</coreappsVersion>
+		<coreappsVersion>1.31.0</coreappsVersion>
 		<databaseBackupVersion>1.3.0</databaseBackupVersion>
 		<dataEntryStatisticsVersion>1.7.0</dataEntryStatisticsVersion>
 		<dataexchangeVersion>1.3.3</dataexchangeVersion>


### PR DESCRIPTION
To reproduce

1. Create a brand new UgandaEMR server, and run the concept script 
2. Run aijar, an error will occur on null value for resultset 

Asana card https://app.asana.com/0/1133167201254915/1199376249117581?mobile_item_action=reply